### PR TITLE
Added support for sampling factor on timing events

### DIFF
--- a/bridge_test.go
+++ b/bridge_test.go
@@ -199,6 +199,21 @@ func TestHandlePacket(t *testing.T) {
 				},
 			},
 		}, {
+			name: "timings with sampling factor",
+			in:   "foo.timing:0.5|ms|@0.1",
+			out: Events{
+				&TimerEvent{metricName: "foo.timing", value: 0.5, labels: map[string]string{}},
+				&TimerEvent{metricName: "foo.timing", value: 0.5, labels: map[string]string{}},
+				&TimerEvent{metricName: "foo.timing", value: 0.5, labels: map[string]string{}},
+				&TimerEvent{metricName: "foo.timing", value: 0.5, labels: map[string]string{}},
+				&TimerEvent{metricName: "foo.timing", value: 0.5, labels: map[string]string{}},
+				&TimerEvent{metricName: "foo.timing", value: 0.5, labels: map[string]string{}},
+				&TimerEvent{metricName: "foo.timing", value: 0.5, labels: map[string]string{}},
+				&TimerEvent{metricName: "foo.timing", value: 0.5, labels: map[string]string{}},
+				&TimerEvent{metricName: "foo.timing", value: 0.5, labels: map[string]string{}},
+				&TimerEvent{metricName: "foo.timing", value: 0.5, labels: map[string]string{}},
+			},
+		}, {
 			name: "bad line",
 			in:   "foo",
 		}, {


### PR DESCRIPTION
Added support for sampling rate in timings. This will for instance accept the statsd line

```
object-server.REPLICATE.timing:0.500917434692|ms|@0.1
```

The above line is real and was sent by openstack swift in our environment.

When a timing event with a sample rate set is received, it will be cloned a number of times in order to simulate it being received without a sampling rate set. This is kind of a dirty hack, but I think that it should be fine in practice. 
