### PR TITLE
fix documentation for docker udp port publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ For example:
 ```bash
 docker pull prom/statsd-exporter
 
-docker run -d -p 9102:9102 -p 9125/udp:9125/udp \
+docker run -d -p 9102:9102 -p 9125:9125/udp \
         -v $PWD/statsd_mapping.conf:/tmp/statsd_mapping.conf \
         prom/statsd-exporter -statsd.mapping-config=/tmp/statsd_mapping.conf
 ```


### PR DESCRIPTION
@juliusv Docker will fail with the current example run command.
```
$ docker run -d -p 9102:9102 -p 9125/udp:9125/udp prom/statsd-exporter
docker: Invalid hostPort: 9125/udp.
```