### PR TITLE
Don't panic when negative number counter is submitted.

### DIFF
--- a/exporter_test.go
+++ b/exporter_test.go
@@ -1,0 +1,52 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// TestNegativeCounter validates when we send a negative
+// number to a counter that we no longer panic the Exporter Listener.
+func TestNegativeCounter(t *testing.T) {
+	defer func() {
+		if e := recover(); e != nil {
+			err := e.(error)
+			if err.Error() == "counter cannot decrease in value" {
+				t.Fatalf("Counter was negative and causes a panic.")
+			} else {
+				t.Fatalf("Unknown panic and error: %q", err.Error())
+			}
+		}
+	}()
+
+	events := make(chan Events, 1)
+	c := Events{
+		&CounterEvent{
+			metricName: "foo",
+			value:      -1,
+		},
+	}
+	events <- c
+	ex := NewExporter(&metricMapper{})
+
+	// Close channel to signify we are done with the listener after a short period.
+	go func() {
+		time.Sleep(time.Millisecond * 100)
+		close(events)
+	}()
+
+	ex.Listen(events)
+}


### PR DESCRIPTION
Instead now we will send a warning message to the logs
and continue on with our day.

Also a guard has been added when we detect a channel has been
closed and the `Exporter.Listen` function will return out of
its loop vs always running. When a channel is closed there will
be no more data to consume, so this seems correct. It also allows
for a test to be written for the panic.

@juliusv @SuperQ 