### PR TITLE
retry: Support datadog extensions to statsd datagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ The exporter will convert DogStatsD-style tags to prometheus labels. See
 documentation for the concept description and
 [Datagram Format](http://docs.datadoghq.com/guides/dogstatsd/#datagram-format)
 for specifics. It boils down to appending
-`|#tag:value,another_tag:another_value` to the normal StatsD format.
+`|#tag:value,another_tag:another_value` to the normal StatsD format.  Tags
+without values (`#some_tag`) are not supported.
 
 ## Building and Running
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ In that case, you don't need to run a StatsD server anymore.
 We recommend this only as an intermediate solution and recommend switching to
 [native Prometheus instrumentation](http://prometheus.io/docs/instrumenting/clientlibs/)
 in the long term.
+
 ### DogStatsD extensions
 
 The exporter will convert DogStatsD-style tags to prometheus labels. See

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The exporter will convert DogStatsD-style tags to prometheus labels. See
 documentation for the concept description and
 [Datagram Format](http://docs.datadoghq.com/guides/dogstatsd/#datagram-format)
 for specifics. It boils down to appending
-`#tag:value,another_tag:another_value` to the normal StatsD format.
+`|#tag:value,another_tag:another_value` to the normal StatsD format.
 
 ## Building and Running
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ In that case, you don't need to run a StatsD server anymore.
 We recommend this only as an intermediate solution and recommend switching to
 [native Prometheus instrumentation](http://prometheus.io/docs/instrumenting/clientlibs/)
 in the long term.
+### DogStatsD extensions
+
+The exporter will convert DogStatsD-style tags to prometheus labels. See
+[Tags](http://docs.datadoghq.com/guides/dogstatsd/#tags) in the DogStatsD
+documentation for the concept description and
+[Datagram Format](http://docs.datadoghq.com/guides/dogstatsd/#datagram-format)
+for specifics. It boils down to appending
+`#tag:value,another_tag:another_value` to the normal StatsD format.
 
 ## Building and Running
 

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -58,12 +58,32 @@ func TestHandlePacket(t *testing.T) {
 			},
 		}, {
 			name: "datadog tag extension",
+			in:   "foo:100|c|#tag1:bar,tag2:baz,tag3,tag4",
+			out: Events{
+				&CounterEvent{
+					metricName: "foo",
+					value:      100,
+					labels:     map[string]string{"tag1": "bar", "tag2": "baz", "tag3": ".", "tag4": "."},
+				},
+			},
+		}, {
+			name: "datadog tag extension with # in all keys (as sent by datadog php client)",
 			in:   "foo:100|c|#tag1:bar,#tag2:baz,#tag3,#tag4",
 			out: Events{
 				&CounterEvent{
 					metricName: "foo",
 					value:      100,
 					labels:     map[string]string{"tag1": "bar", "tag2": "baz", "tag3": ".", "tag4": "."},
+				},
+			},
+		}, {
+			name: "datadog tag extension with tags unsupported by prometheus",
+			in:   "foo:100|c|#09digits:0,tag.with.dots,tag_with_empty_value:",
+			out: Events{
+				&CounterEvent{
+					metricName: "foo",
+					value:      100,
+					labels:     map[string]string{"_09digits": "0", "tag_with_dots": ".", "tag_with_empty_value": "."},
 				},
 			},
 		}, {

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -97,6 +97,16 @@ func TestHandlePacket(t *testing.T) {
 				},
 			},
 		}, {
+			name: "datadog tag extension with multiple colons",
+			in:   "foo:100|c|@0.1|#tag1:foo:bar",
+			out: Events{
+				&CounterEvent{
+					metricName: "foo",
+					value:      1000,
+					labels:     map[string]string{"tag1": "foo:bar"},
+				},
+			},
+		}, {
 			name: "combined multiline metrics",
 			in:   "foo:200|ms:300|ms:5|c|@0.1:6|g\nbar:1|c:5|ms",
 			out: Events{

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -58,7 +58,7 @@ func TestHandlePacket(t *testing.T) {
 			},
 		}, {
 			name: "datadog tag extension",
-			in:   "foo:100|c|#tag1:bar,tag2:baz,tag3,tag4",
+			in:   "foo:100|c|#tag1:bar,#tag2:baz,#tag3,#tag4",
 			out: Events{
 				&CounterEvent{
 					metricName: "foo",
@@ -68,7 +68,7 @@ func TestHandlePacket(t *testing.T) {
 			},
 		}, {
 			name: "datadog tag extension with sampling",
-			in:   "foo:100|c|@0.1|#tag1:bar,tag2,tag3:baz",
+			in:   "foo:100|c|@0.1|#tag1:bar,#tag2,#tag3:baz",
 			out: Events{
 				&CounterEvent{
 					metricName: "foo",

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -63,7 +63,7 @@ func TestHandlePacket(t *testing.T) {
 				&CounterEvent{
 					metricName: "foo",
 					value:      100,
-					labels:     map[string]string{"tag1": "bar", "tag2": "baz", "tag3": ".", "tag4": "."},
+					labels:     map[string]string{"tag1": "bar", "tag2": "baz", "tag3": "<n/a>", "tag4": "<n/a>"},
 				},
 			},
 		}, {
@@ -73,7 +73,7 @@ func TestHandlePacket(t *testing.T) {
 				&CounterEvent{
 					metricName: "foo",
 					value:      100,
-					labels:     map[string]string{"tag1": "bar", "tag2": "baz", "tag3": ".", "tag4": "."},
+					labels:     map[string]string{"tag1": "bar", "tag2": "baz", "tag3": "<n/a>", "tag4": "<n/a>"},
 				},
 			},
 		}, {
@@ -83,7 +83,7 @@ func TestHandlePacket(t *testing.T) {
 				&CounterEvent{
 					metricName: "foo",
 					value:      100,
-					labels:     map[string]string{"_09digits": "0", "tag_with_dots": ".", "tag_with_empty_value": "."},
+					labels:     map[string]string{"_09digits": "0", "tag_with_dots": "<n/a>", "tag_with_empty_value": "<n/a>"},
 				},
 			},
 		}, {
@@ -93,7 +93,7 @@ func TestHandlePacket(t *testing.T) {
 				&CounterEvent{
 					metricName: "foo",
 					value:      1000,
-					labels:     map[string]string{"tag1": "bar", "tag2": ".", "tag3": "baz"},
+					labels:     map[string]string{"tag1": "bar", "tag2": "<n/a>", "tag3": "baz"},
 				},
 			},
 		}, {

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -58,42 +58,72 @@ func TestHandlePacket(t *testing.T) {
 			},
 		}, {
 			name: "datadog tag extension",
-			in:   "foo:100|c|#tag1:bar,tag2:baz,tag3,tag4",
+			in:   "foo:100|c|#tag1:bar,tag2:baz",
 			out: Events{
 				&CounterEvent{
 					metricName: "foo",
 					value:      100,
-					labels:     map[string]string{"tag1": "bar", "tag2": "baz", "tag3": "<n/a>", "tag4": "<n/a>"},
+					labels:     map[string]string{"tag1": "bar", "tag2": "baz"},
 				},
 			},
 		}, {
 			name: "datadog tag extension with # in all keys (as sent by datadog php client)",
-			in:   "foo:100|c|#tag1:bar,#tag2:baz,#tag3,#tag4",
+			in:   "foo:100|c|#tag1:bar,#tag2:baz",
 			out: Events{
 				&CounterEvent{
 					metricName: "foo",
 					value:      100,
-					labels:     map[string]string{"tag1": "bar", "tag2": "baz", "tag3": "<n/a>", "tag4": "<n/a>"},
+					labels:     map[string]string{"tag1": "bar", "tag2": "baz"},
 				},
 			},
 		}, {
-			name: "datadog tag extension with tags unsupported by prometheus",
-			in:   "foo:100|c|#09digits:0,tag.with.dots,tag_with_empty_value:",
+			name: "datadog tag extension with tag keys unsupported by prometheus",
+			in:   "foo:100|c|#09digits:0,tag.with.dots:1",
 			out: Events{
 				&CounterEvent{
 					metricName: "foo",
 					value:      100,
-					labels:     map[string]string{"_09digits": "0", "tag_with_dots": "<n/a>", "tag_with_empty_value": "<n/a>"},
+					labels:     map[string]string{"_09digits": "0", "tag_with_dots": "1"},
+				},
+			},
+		}, {
+			name: "datadog tag extension with valueless tags: ignored",
+			in:   "foo:100|c|#tag_without_a_value",
+			out: Events{
+				&CounterEvent{
+					metricName: "foo",
+					value:      100,
+					labels:     map[string]string{},
+				},
+			},
+		}, {
+			name: "datadog tag extension with valueless tags (edge case)",
+			in:   "foo:100|c|#tag_without_a_value,tag:value",
+			out: Events{
+				&CounterEvent{
+					metricName: "foo",
+					value:      100,
+					labels:     map[string]string{"tag": "value"},
+				},
+			},
+		}, {
+			name: "datadog tag extension with empty tags (edge case)",
+			in:   "foo:100|c|#tag:value,,",
+			out: Events{
+				&CounterEvent{
+					metricName: "foo",
+					value:      100,
+					labels:     map[string]string{"tag": "value"},
 				},
 			},
 		}, {
 			name: "datadog tag extension with sampling",
-			in:   "foo:100|c|@0.1|#tag1:bar,#tag2,#tag3:baz",
+			in:   "foo:100|c|@0.1|#tag1:bar,#tag2:baz",
 			out: Events{
 				&CounterEvent{
 					metricName: "foo",
 					value:      1000,
-					labels:     map[string]string{"tag1": "bar", "tag2": "<n/a>", "tag3": "baz"},
+					labels:     map[string]string{"tag1": "bar", "tag2": "baz"},
 				},
 			},
 		}, {

--- a/exporter.go
+++ b/exporter.go
@@ -359,7 +359,6 @@ func (l *StatsDListener) handlePacket(packet []byte, e chan<- Events) {
 				continue
 			}
 			valueStr, statType := components[0], components[1]
-			labels := map[string]string{}
 			value, err := strconv.ParseFloat(valueStr, 64)
 			if err != nil {
 				log.Printf("Bad value %s on line: %s", valueStr, line)
@@ -367,6 +366,7 @@ func (l *StatsDListener) handlePacket(packet []byte, e chan<- Events) {
 				continue
 			}
 
+			labels := map[string]string{}
 			if len(components) >= 3 {
 				for _, component := range components[2:] {
 					switch component[0] {

--- a/exporter.go
+++ b/exporter.go
@@ -310,7 +310,7 @@ func parseDogStatsDTagsToLabels(component string) map[string]string {
 	tags := strings.Split(component, ",")
 	for _, t := range tags {
 		t = strings.TrimPrefix(t, "#")
-		kv := strings.Split(t, ":")
+		kv := strings.SplitN(t, ":", 2)
 		key := escapeMetricName(kv[0])
 
 		var value string

--- a/exporter.go
+++ b/exporter.go
@@ -360,7 +360,7 @@ func (l *StatsDListener) handlePacket(packet []byte, e chan<- Events) {
 						}
 						value /= samplingFactor
 					case '#':
-						networkStats.WithLabelValues("dogstasd_tags").Inc()
+						networkStats.WithLabelValues("dogstatsd_tags").Inc()
 						tags := strings.Split(component, ",")
 						for _, t := range tags {
 							t = strings.TrimPrefix(t, "#")

--- a/exporter.go
+++ b/exporter.go
@@ -361,15 +361,17 @@ func (l *StatsDListener) handlePacket(packet []byte, e chan<- Events) {
 						value /= samplingFactor
 					case '#':
 						networkStats.WithLabelValues("dogstasd_tags").Inc()
-						tags := strings.Split(component[1:], ",")
+						tags := strings.Split(component, ",")
 						for _, t := range tags {
 							kv := strings.Split(t, ":")
 							if len(kv) == 2 {
 								if len(kv[1]) > 0 {
-									labels[kv[0]] = kv[1]
+									var metric_key = kv[0][1:]
+									metric_key = strings.Trim(metric_key, " ")
+									labels[metric_key] = kv[1]
 								}
 							} else if len(kv) == 1 {
-								labels[kv[0]] = "."
+								labels[kv[0][1:]] = "."
 							}
 						}
 					default:

--- a/exporter.go
+++ b/exporter.go
@@ -363,16 +363,22 @@ func (l *StatsDListener) handlePacket(packet []byte, e chan<- Events) {
 						networkStats.WithLabelValues("dogstasd_tags").Inc()
 						tags := strings.Split(component, ",")
 						for _, t := range tags {
+							t = strings.TrimPrefix(t, "#")
 							kv := strings.Split(t, ":")
+							tag_key := kv[0]
+							tag_key = escapeMetricName(tag_key)
+
+							var tag_value string
 							if len(kv) == 2 {
 								if len(kv[1]) > 0 {
-									var metric_key = kv[0][1:]
-									metric_key = strings.Trim(metric_key, " ")
-									labels[metric_key] = kv[1]
+									tag_value = kv[1]
+								} else {
+									tag_value = "."
 								}
 							} else if len(kv) == 1 {
-								labels[kv[0][1:]] = "."
+								tag_value = "."
 							}
+							labels[tag_key] = tag_value
 						}
 					default:
 						log.Printf("Invalid sampling factor or tag section %s on line %s", components[2], line)

--- a/exporter.go
+++ b/exporter.go
@@ -33,6 +33,7 @@ const (
 	regErrF     = "A change of configuration created inconsistent metrics for " +
 		"%q. You have to restart the statsd_exporter, and you should " +
 		"consider the effects on your monitoring setup. Error: %s"
+	dogStatsDDefaultTagValue = "<n/a>"
 )
 
 var (
@@ -317,10 +318,10 @@ func parseDogStatsDTagsToLabels(component string) map[string]string {
 			if len(kv[1]) > 0 {
 				value = kv[1]
 			} else {
-				value = "."
+				value = dogStatsDDefaultTagValue
 			}
 		} else if len(kv) == 1 {
-			value = "."
+			value = dogStatsDDefaultTagValue
 		}
 		labels[key] = value
 	}


### PR DESCRIPTION
This is a rebased and improved version of https://github.com/prometheus/statsd_exporter/pull/3

We added some validation to DogStatsD tags and some tests. We also took it for a test run(it worked nicely) and plan to use it in production when this is merged.

We also added a special-case handling for the php dogstatsd client, which prefixes every tag with a `#`: https://github.com/DataDog/php-datadogstatsd/issues/35

I think that DogStatsD tags is a generally useful extension to StatsD protocol.

cc @pjjw @Bonko