### PR TITLE
Make metric suffixes optional, expose unmapped events

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -218,6 +218,7 @@ func (b *Exporter) Listen(e <-chan Events) {
 					}
 				}
 			} else {
+				eventsUnmapped.Inc()
 				metricName = escapeMetricName(event.MetricName())
 			}
 

--- a/exporter.go
+++ b/exporter.go
@@ -176,6 +176,7 @@ type Exporter struct {
 	Gauges    *GaugeContainer
 	Summaries *SummaryContainer
 	mapper    *metricMapper
+	addSuffix bool
 }
 
 func escapeMetricName(metricName string) string {
@@ -187,6 +188,14 @@ func escapeMetricName(metricName string) string {
 	// Replace all illegal metric chars with underscores.
 	metricName = illegalCharsRE.ReplaceAllString(metricName, "_")
 	return metricName
+}
+
+func (b *Exporter) suffix(metricName, suffix string) string {
+	str := metricName
+	if b.addSuffix {
+		str += "_" + suffix
+	}
+	return str
 }
 
 func (b *Exporter) Listen(e <-chan Events) {
@@ -215,7 +224,7 @@ func (b *Exporter) Listen(e <-chan Events) {
 			switch event.(type) {
 			case *CounterEvent:
 				counter := b.Counters.Get(
-					metricName+"_counter",
+					b.suffix(metricName, "counter"),
 					prometheusLabels,
 				)
 				// We don't accept negative values for counters. Incrementing the counter with a negative number
@@ -231,7 +240,7 @@ func (b *Exporter) Listen(e <-chan Events) {
 
 			case *GaugeEvent:
 				gauge := b.Gauges.Get(
-					metricName+"_gauge",
+					b.suffix(metricName, "gauge"),
 					prometheusLabels,
 				)
 				gauge.Set(event.Value())
@@ -240,7 +249,7 @@ func (b *Exporter) Listen(e <-chan Events) {
 
 			case *TimerEvent:
 				summary := b.Summaries.Get(
-					metricName+"_timer",
+					b.suffix(metricName, "timer"),
 					prometheusLabels,
 				)
 				summary.Observe(event.Value())
@@ -255,8 +264,9 @@ func (b *Exporter) Listen(e <-chan Events) {
 	}
 }
 
-func NewExporter(mapper *metricMapper) *Exporter {
+func NewExporter(mapper *metricMapper, addSuffix bool) *Exporter {
 	return &Exporter{
+		addSuffix: addSuffix,
 		Counters:  NewCounterContainer(),
 		Gauges:    NewGaugeContainer(),
 		Summaries: NewSummaryContainer(),

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ var (
 	statsdListenAddress = flag.String("statsd.listen-address", ":9125", "The UDP address on which to receive statsd metric lines.")
 	mappingConfig       = flag.String("statsd.mapping-config", "", "Metric mapping configuration file name.")
 	readBuffer          = flag.Int("statsd.read-buffer", 0, "Size (in bytes) of the operating system's transmit read buffer associated with the UDP connection. Please make sure the kernel parameters net.core.rmem_max is set to a value greater than the value specified.")
+	addSuffix           = flag.Bool("statsd.add-suffix", true, "Add the metric type (counter/gauge/timer) as suffix to the generated Prometheus metric (NOT recommended, but set by default for backward compatibility).")
 )
 
 func serveHTTP() {
@@ -108,6 +109,9 @@ func watchConfig(fileName string, mapper *metricMapper) {
 func main() {
 	flag.Parse()
 
+	if *addSuffix {
+		log.Println("Warning: Using -statsd.add-suffix is discouraged. We recommend explicitly naming metrics appropriately in the mapping configuration.")
+	}
 	log.Println("Starting StatsD -> Prometheus Exporter...")
 	log.Println("Accepting StatsD Traffic on", *statsdListenAddress)
 	log.Println("Accepting Prometheus Requests on", *listenAddress)
@@ -141,6 +145,6 @@ func main() {
 		}
 		go watchConfig(*mappingConfig, mapper)
 	}
-	exporter := NewExporter(mapper)
+	exporter := NewExporter(mapper, *addSuffix)
 	exporter.Listen(events)
 }

--- a/telemetry.go
+++ b/telemetry.go
@@ -25,6 +25,10 @@ var (
 		},
 		[]string{"type"},
 	)
+	eventsUnmapped = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "statsd_exporter_events_unmapped_total",
+		Help: "The total number of StatsD events no mapping was found for.",
+	})
 	networkStats = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "statsd_exporter_packets_total",
@@ -41,7 +45,7 @@ var (
 	)
 	mappingsCount = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "statsd_exporter_loaded_mappings_count",
-		Help: "The number of configured metric mappings.",
+		Help: "The current number of configured metric mappings.",
 	})
 )
 


### PR DESCRIPTION
I change the README to show all examples without the auto suffixes but mention that, for now, they still get added. I did that because I think in one of the next releases we should change the defaults: Even though it might break things, I believe all our exporters should be serve as idiomatic example which here isn't the case.