### PR TITLE
Drop _count suffix for loaded_mappings metric 

### DIFF
--- a/telemetry.go
+++ b/telemetry.go
@@ -44,7 +44,7 @@ var (
 		[]string{"outcome"},
 	)
 	mappingsCount = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "statsd_exporter_loaded_mappings_count",
+		Name: "statsd_exporter_loaded_mappings",
 		Help: "The current number of configured metric mappings.",
 	})
 )


### PR DESCRIPTION
This makes the naming consistent with our best pratices.