### PR TITLE
Tolerate more forms of broken lines from StatsD

### DIFF
--- a/bridge_test.go
+++ b/bridge_test.go
@@ -204,6 +204,14 @@ func TestHandlePacket(t *testing.T) {
 			name: "illegal stat type",
 			in:   "foo:2|t",
 		},
+		{
+			name: "empty metric name",
+			in:   ":100|ms",
+		},
+		{
+			name: "empty component",
+			in:   "foo:1|c|",
+		},
 	}
 
 	l := StatsDListener{}


### PR DESCRIPTION
This changeset makes statsd_exporter more tolerant of two kinds of
broken metrics.

## `:100|ms`

With this changeset:

```
ERRO[0038] Bad line from StatsD: :100|ms                 source=exporter.go:357
```

With master:

```
panic: runtime error: index out of range

goroutine 1 [running]:
panic(0x86ccc0, 0xc8200100a0)
        /usr/lib/go/src/runtime/panic.go:464 +0x3e6
main.escapeMetricName(0xc820109328, 0x0, 0x0, 0x0)
        /home/haguenau/etc/statsd_exporter/exporter.go:191 +0xe5
main.(*Exporter).Listen(0xc820101f10, 0xc82001cba0)
        /home/haguenau/etc/statsd_exporter/exporter.go:229 +0xf67
main.main()
        /home/haguenau/etc/statsd_exporter/main.go:163 +0x1002
```


## `foo:1|c|`

With this changeset:

```
ERRO[0001] Empty component on line:  foo:1|c|            source=exporter.go:388
```

With master:

```
panic: runtime error: index out of range

goroutine 13 [running]:
panic(0x86ccc0, 0xc8200100a0)
        /usr/lib/go/src/runtime/panic.go:464 +0x3e6
main.(*StatsDListener).handlePacket(0xc8200320c8, 0xc820189ed1, 0x9, 0xffff, 0xc82001cba0)
        /home/haguenau/etc/statsd_exporter/exporter.go:387 +0x1702
main.(*StatsDListener).Listen(0xc8200320c8, 0xc82001cba0)
        /home/haguenau/etc/statsd_exporter/exporter.go:323 +0x20e
created by main.main
        /home/haguenau/etc/statsd_exporter/main.go:152 +0xc00
```
