### PR TITLE
Skip metrics with invalid utf8

### DIFF
--- a/bridge_test.go
+++ b/bridge_test.go
@@ -137,6 +137,22 @@ func TestHandlePacket(t *testing.T) {
 				},
 			},
 		}, {
+			name: "datadog tag extension with invalid utf8 tag values",
+			in:   "foo:100|c|@0.1|#tag:\xc3\x28invalid",
+		}, {
+			name: "datadog tag extension with both valid and invalid utf8 tag values",
+			in:   "foo:100|c|@0.1|#tag1:valid,tag2:\xc3\x28invalid",
+		}, {
+			name: "multiple metrics with invalid datadog utf8 tag values",
+			in:   "foo:200|c|#tag:value\nfoo:300|c|#tag:\xc3\x28invalid",
+			out: Events{
+				&CounterEvent{
+					metricName: "foo",
+					value:      200,
+					labels:     map[string]string{"tag": "value"},
+				},
+			},
+		}, {
 			name: "combined multiline metrics",
 			in:   "foo:200|ms:300|ms:5|c|@0.1:6|g\nbar:1|c:5|ms",
 			out: Events{
@@ -211,6 +227,21 @@ func TestHandlePacket(t *testing.T) {
 		{
 			name: "empty component",
 			in:   "foo:1|c|",
+		},
+		{
+			name: "invalid utf8",
+			in:   "invalid\xc3\x28utf8:1|c",
+		},
+		{
+			name: "some invalid utf8",
+			in:   "valid_utf8:1|c\ninvalid\xc3\x28utf8:1|c",
+			out: Events{
+				&CounterEvent{
+					metricName: "valid_utf8",
+					value:      1,
+					labels:     map[string]string{},
+				},
+			},
 		},
 	}
 

--- a/exporter.go
+++ b/exporter.go
@@ -351,6 +351,7 @@ func (l *StatsDListener) handlePacket(packet []byte, e chan<- Events) {
 		if line == "" {
 			continue
 		}
+
 		elements := strings.SplitN(line, ":", 2)
 		if len(elements) < 2 || len(elements[0]) == 0 || !utf8.ValidString(line) {
 			networkStats.WithLabelValues("malformed_line").Inc()
@@ -365,8 +366,7 @@ func (l *StatsDListener) handlePacket(packet []byte, e chan<- Events) {
 		} else {
 			samples = strings.Split(elements[1], ":")
 		}
-	samples:
-		for _, sample := range samples {
+		samples: for _, sample := range samples {
 			components := strings.Split(sample, "|")
 			samplingFactor := 1.0
 			if len(components) < 2 || len(components) > 4 {

--- a/exporter_benchmark_test.go
+++ b/exporter_benchmark_test.go
@@ -1,0 +1,61 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+func benchmarkExporter(times int, b *testing.B) {
+	input := []string{
+		"foo1:2|c",
+		"foo2:3|g",
+		"foo3:200|ms",
+		"foo4:100|c|#tag1:bar,tag2:baz",
+		"foo5:100|c|#tag1:bar,#tag2:baz",
+		"foo6:100|c|#09digits:0,tag.with.dots:1",
+		"foo10:100|c|@0.1|#tag1:bar,#tag2:baz",
+		"foo11:100|c|@0.1|#tag1:foo:bar",
+		"foo15:200|ms:300|ms:5|c|@0.1:6|g\nfoo15a:1|c:5|ms",
+		"some_very_useful_metrics_with_quite_a_log_name:13|c",
+	}
+	bytesInput := make([]string, len(input)*times)
+	for run := 0; run < times; run++ {
+		for i := 0; i < len(input); i++ {
+			bytesInput[run*len(input)+i] = fmt.Sprintf("run%d%s", run, input[i])
+		}
+	}
+	for n := 0; n < b.N; n++ {
+		l := StatsDListener{}
+		// there are more events than input lines, need bigger buffer
+		events := make(chan Events, len(bytesInput)*times*2)
+
+		for i := 0; i < times; i++ {
+			for _, line := range bytesInput {
+				l.handlePacket([]byte(line), events)
+			}
+		}
+	}
+}
+
+func BenchmarkExporter1(b *testing.B) {
+	benchmarkExporter(1, b)
+}
+func BenchmarkExporter5(b *testing.B) {
+	benchmarkExporter(5, b)
+}
+func BenchmarkExporter50(b *testing.B) {
+	benchmarkExporter(50, b)
+}


### PR DESCRIPTION
This would prevent an incident I have been seeing:

The exporter will happily store metrics with invalid utf8 in labels. Prometheus will then try to collect them and will choke on invalid utf8, [here](https://github.com/prometheus/prometheus/blob/e83f05fe93c32c9e808b2a6a907337b442a540dc/vendor/github.com/prometheus/common/model/labels.go#L157) and [here](https://github.com/prometheus/prometheus/blob/dc4d5fef2a75b9b4e5124fe41ec291eda52f667e/vendor/github.com/prometheus/common/expfmt/decode.go#L104) I think. The statsd-exporter target will be  marked down because of this error.

I wonder if the `utf8.ValidString` check for every input line would make StatsD ingestion considerably slower/increase CPU usage?

I've tried to only check DogStatsD tag values first, but it wasn't enough and it was too much code. Which explains the many new tests.

TODO
 - [x] remove unintended changes