### PR TITLE
ListenAndServe now fails on exit

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func serveHTTP() {
 			</body>
 			</html>`))
 	})
-	http.ListenAndServe(*listenAddress, nil)
+	log.Fatal(http.ListenAndServe(*listenAddress, nil))
 }
 
 func udpAddrFromString(addr string) *net.UDPAddr {


### PR DESCRIPTION
ListenAndServe shouldn't fail silently in self goroutine, now it calling log.Fatal