### PR TITLE
Improve mapping configuration parser

### DIFF
--- a/mapper.go
+++ b/mapper.go
@@ -77,19 +77,10 @@ func (m *metricMapper) initFromString(fileContents string) error {
 			state = METRIC_DEFINITION
 
 		case METRIC_DEFINITION:
-			emptyLine, lastLine := false, false
+			if (i == numLines-1) && (line != "") {
+				return fmt.Errorf("Line %d: missing terminating newline", i)
+			}
 			if line == "" {
-				emptyLine = true
-			}
-			if i == numLines-1 {
-				lastLine = true
-			}
-			if (emptyLine) || (lastLine) {
-				if !emptyLine {
-					if err := m.updateMapping(line, i, &currentMapping); err != nil {
-						return err
-					}
-				}
 				if len(currentMapping.labels) == 0 {
 					return fmt.Errorf("Line %d: metric mapping didn't set any labels", i)
 				}

--- a/mapper.go
+++ b/mapper.go
@@ -51,6 +51,7 @@ const (
 
 func (m *metricMapper) initFromString(fileContents string) error {
 	lines := strings.Split(fileContents, "\n")
+	numLines := len(lines)
 	state := SEARCHING
 
 	parsedMappings := []metricMapping{}
@@ -76,7 +77,7 @@ func (m *metricMapper) initFromString(fileContents string) error {
 			state = METRIC_DEFINITION
 
 		case METRIC_DEFINITION:
-			if line == "" {
+			if (line == "") || (i == numLines-1) {
 				if len(currentMapping.labels) == 0 {
 					return fmt.Errorf("Line %d: metric mapping didn't set any labels", i)
 				}

--- a/mapper.go
+++ b/mapper.go
@@ -77,30 +77,33 @@ func (m *metricMapper) initFromString(fileContents string) error {
 			state = METRIC_DEFINITION
 
 		case METRIC_DEFINITION:
-			if (line == "") || (i == numLines-1) {
+			emptyLine, lastLine := false, false
+			if line == "" {
+				emptyLine = true
+			}
+			if i == numLines-1 {
+				lastLine = true
+			}
+			if (emptyLine) || (lastLine) {
+				if !emptyLine {
+					if err := m.updateMapping(line, i, &currentMapping); err != nil {
+						return err
+					}
+				}
 				if len(currentMapping.labels) == 0 {
 					return fmt.Errorf("Line %d: metric mapping didn't set any labels", i)
 				}
 				if _, ok := currentMapping.labels["name"]; !ok {
 					return fmt.Errorf("Line %d: metric mapping didn't set a metric name", i)
 				}
-
 				parsedMappings = append(parsedMappings, currentMapping)
-
 				state = SEARCHING
 				currentMapping = metricMapping{labels: prometheus.Labels{}}
 				continue
 			}
-
-			matches := labelLineRE.FindStringSubmatch(line)
-			if len(matches) != 3 {
-				return fmt.Errorf("Line %d: expected label mapping line, got: %s", i, line)
+			if err := m.updateMapping(line, i, &currentMapping); err != nil {
+				return err
 			}
-			label, value := matches[1], matches[2]
-			if label == "name" && !metricNameRE.MatchString(value) {
-				return fmt.Errorf("Line %d: metric name '%s' doesn't match regex '%s'", i, value, metricNameRE)
-			}
-			currentMapping.labels[label] = value
 		default:
 			panic("illegal state")
 		}
@@ -142,4 +145,17 @@ func (m *metricMapper) getMapping(statsdMetric string) (labels prometheus.Labels
 	}
 
 	return nil, false
+}
+
+func (m *metricMapper) updateMapping(line string, i int, mapping *metricMapping) error {
+	matches := labelLineRE.FindStringSubmatch(line)
+	if len(matches) != 3 {
+		return fmt.Errorf("Line %d: expected label mapping line, got: %s", i, line)
+	}
+	label, value := matches[1], matches[2]
+	if label == "name" && !metricNameRE.MatchString(value) {
+		return fmt.Errorf("Line %d: metric name '%s' doesn't match regex '%s'", i, value, metricNameRE)
+	}
+	(*mapping).labels[label] = value
+	return nil
 }

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -134,6 +134,19 @@ func TestMetricMapper(t *testing.T) {
 			`,
 			configBad: true,
 		},
+		// Config without a terminating newline.
+		{
+			config: `
+				test.*
+				name="name"
+				label="foo"`,
+			mappings: map[string]map[string]string{
+				"test.a": map[string]string{
+					"name":  "name",
+					"label": "foo",
+				},
+			},
+		},
 	}
 
 	mapper := metricMapper{}

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -140,12 +140,7 @@ func TestMetricMapper(t *testing.T) {
 				test.*
 				name="name"
 				label="foo"`,
-			mappings: map[string]map[string]string{
-				"test.a": map[string]string{
-					"name":  "name",
-					"label": "foo",
-				},
-			},
+			configBad: true,
 		},
 		// Multiple mapping configs and no terminating newline.
 		{
@@ -157,16 +152,7 @@ func TestMetricMapper(t *testing.T) {
 				test.foo
 				name="name_foo"
 				label="bar"`,
-			mappings: map[string]map[string]string{
-				"test.bar": map[string]string{
-					"name":  "name_bar",
-					"label": "foo",
-				},
-				"test.foo": map[string]string{
-					"name":  "name_foo",
-					"label": "bar",
-				},
-			},
+			configBad: true,
 		},
 	}
 

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -134,7 +134,7 @@ func TestMetricMapper(t *testing.T) {
 			`,
 			configBad: true,
 		},
-		// Config without a terminating newline.
+		// A single mapping config without a terminating newline.
 		{
 			config: `
 				test.*
@@ -144,6 +144,27 @@ func TestMetricMapper(t *testing.T) {
 				"test.a": map[string]string{
 					"name":  "name",
 					"label": "foo",
+				},
+			},
+		},
+		// Multiple mapping configs and no terminating newline.
+		{
+			config: `
+				test.bar
+				name="name_bar"
+				label="foo"
+				
+				test.foo
+				name="name_foo"
+				label="bar"`,
+			mappings: map[string]map[string]string{
+				"test.bar": map[string]string{
+					"name":  "name_bar",
+					"label": "foo",
+				},
+				"test.foo": map[string]string{
+					"name":  "name_foo",
+					"label": "bar",
 				},
 			},
 		},


### PR DESCRIPTION
Issue #55 shows that the mapping config is not parsed in full if a terminating newline is missing. The last metric mapping is not parsed at all and no errors are shown. This PR changes the parsing method by treating the last line of the file as if it would be a newline between two mappings.

Added two new testcases to `mapper_test.go`:

- a single mapping configuration without a terminating newline
- two mapping configurations without a terminating newline

Tested by running `go test` and it gives a big thumbs up. In addition I tested this locally by running `prom/statsd-exporter` (Dockerhub) and the fixed version side-by-side with this mapping:

```
*.test.*
name="test"
foo="$1"
bar="$2 <no newline>
```

Results for the official image:

```
$ curl -s 127.0.0.1:9102/metrics | grep ^statsd_exporter_build_info
statsd_exporter_build_info{branch="master",goversion="go1.6.2",revision="e00d9e8",version="0.3.0"} 1
$ (curl -s 127.0.0.1:9102/metrics | grep ^test) || echo ":("
:(
$ echo "foo.test.bar:1|g" >/dev/udp/127.0.0.1/9125
$ (curl -s 127.0.0.1:9102/metrics | grep ^test) || echo ":("
:(
```

Results after applying this PR:

```
$ curl -s 127.0.0.1:9102/metrics | grep ^statsd_exporter_build_info
statsd_exporter_build_info{branch="",goversion="go1.6.4",revision="",version=""} 1
$ (curl -s 127.0.0.1:9102/metrics | grep ^test) || echo ":("
:(
$ echo "foo.test.bar:1|g" >/dev/udp/127.0.0.1/9125
$ (curl -s 127.0.0.1:9102/metrics | grep ^test) || echo ":("
test{bar="bar",foo="foo"} 1
```

Pinging @juliusv as instructed in `CONTRIBUTIONS.md`.