### PR TITLE
Resolves #77 add cmdline flag to drop unmapped

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -266,6 +266,9 @@ func (b *Exporter) Listen(e <-chan Events) {
 				}
 			} else {
 				eventsUnmapped.Inc()
+				if *dropUnmapped == true {
+					continue
+				}
 				metricName = escapeMetricName(event.MetricName())
 			}
 

--- a/exporter.go
+++ b/exporter.go
@@ -218,12 +218,13 @@ func (c *TimerEvent) Labels() map[string]string { return c.labels }
 type Events []Event
 
 type Exporter struct {
-	Counters   *CounterContainer
-	Gauges     *GaugeContainer
-	Summaries  *SummaryContainer
-	Histograms *HistogramContainer
-	mapper     *metricMapper
-	addSuffix  bool
+	Counters     *CounterContainer
+	Gauges       *GaugeContainer
+	Summaries    *SummaryContainer
+	Histograms   *HistogramContainer
+	mapper       *metricMapper
+	addSuffix    bool
+	dropUnmapped bool
 }
 
 func escapeMetricName(metricName string) string {
@@ -266,7 +267,7 @@ func (b *Exporter) Listen(e <-chan Events) {
 				}
 			} else {
 				eventsUnmapped.Inc()
-				if *dropUnmapped == true {
+				if b.dropUnmapped == true {
 					continue
 				}
 				metricName = escapeMetricName(event.MetricName())
@@ -362,14 +363,15 @@ func (b *Exporter) Listen(e <-chan Events) {
 	}
 }
 
-func NewExporter(mapper *metricMapper, addSuffix bool) *Exporter {
+func NewExporter(mapper *metricMapper, addSuffix bool, dropUnmapped bool) *Exporter {
 	return &Exporter{
-		addSuffix:  addSuffix,
-		Counters:   NewCounterContainer(),
-		Gauges:     NewGaugeContainer(),
-		Summaries:  NewSummaryContainer(),
-		Histograms: NewHistogramContainer(mapper),
-		mapper:     mapper,
+		addSuffix:    addSuffix,
+		dropUnmapped: dropUnmapped,
+		Counters:     NewCounterContainer(),
+		Gauges:       NewGaugeContainer(),
+		Summaries:    NewSummaryContainer(),
+		Histograms:   NewHistogramContainer(mapper),
+		mapper:       mapper,
 	}
 }
 

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -42,7 +42,7 @@ func TestNegativeCounter(t *testing.T) {
 		},
 	}
 	events <- c
-	ex := NewExporter(&metricMapper{}, true)
+	ex := NewExporter(&metricMapper{}, true, false)
 
 	// Close channel to signify we are done with the listener after a short period.
 	go func() {
@@ -57,7 +57,6 @@ func TestNegativeCounter(t *testing.T) {
 // metrics from being recorded when set true and that they are recorded when set
 // false.
 func TestDropUnmapped(t *testing.T) {
-	dropUnmapped = func() *bool { b := true; return &b }()
 	events := make(chan Events, 1)
 	c := Events{
 		&CounterEvent{
@@ -66,7 +65,7 @@ func TestDropUnmapped(t *testing.T) {
 		},
 	}
 	events <- c
-	ex := NewExporter(&metricMapper{}, true)
+	ex := NewExporter(&metricMapper{}, true, true)
 
 	// Close channel to signify we are done with the listener after a short period.
 	go func() {
@@ -78,7 +77,7 @@ func TestDropUnmapped(t *testing.T) {
 	if len(ex.Counters.Elements) != 0 {
 		t.Fatalf("Unmapped metric recorded inspite of dropUnmapped being set true")
 	}
-	dropUnmapped = func() *bool { b := false; return &b }()
+	ex = NewExporter(&metricMapper{}, true, false)
 	events = make(chan Events, 1)
 	events <- c
 	// Close channel to signify we are done with the listener after a short period.
@@ -97,7 +96,7 @@ func TestDropUnmapped(t *testing.T) {
 // It sends the same tags first with a valid value, then with an invalid one.
 // The exporter should not panic, but drop the invalid event
 func TestInvalidUtf8InDatadogTagValue(t *testing.T) {
-	ex := NewExporter(&metricMapper{}, true)
+	ex := NewExporter(&metricMapper{}, true, false)
 	for _, l := range []statsDPacketHandler{&StatsDUDPListener{}, &mockStatsDTCPListener{}} {
 		events := make(chan Events, 2)
 

--- a/main.go
+++ b/main.go
@@ -40,8 +40,8 @@ var (
 	mappingConfig       = flag.String("statsd.mapping-config", "", "Metric mapping configuration file name.")
 	readBuffer          = flag.Int("statsd.read-buffer", 0, "Size (in bytes) of the operating system's transmit read buffer associated with the UDP connection. Please make sure the kernel parameters net.core.rmem_max is set to a value greater than the value specified.")
 	addSuffix           = flag.Bool("statsd.add-suffix", true, "Add the metric type (counter/gauge/timer) as suffix to the generated Prometheus metric (NOT recommended, but set by default for backward compatibility).")
-	showVersion         = flag.Bool("version", false, "Print version information.")
 	dropUnmapped        = flag.Bool("statsd.drop-unmapped", false, "Drop statsd metrics which have no matched mapping configured.")
+	showVersion         = flag.Bool("version", false, "Print version information.")
 )
 
 func serveHTTP() {
@@ -200,6 +200,6 @@ func main() {
 		}
 		go watchConfig(*mappingConfig, mapper)
 	}
-	exporter := NewExporter(mapper, *addSuffix)
+	exporter := NewExporter(mapper, *addSuffix, *dropUnmapped)
 	exporter.Listen(events)
 }

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ var (
 	readBuffer          = flag.Int("statsd.read-buffer", 0, "Size (in bytes) of the operating system's transmit read buffer associated with the UDP connection. Please make sure the kernel parameters net.core.rmem_max is set to a value greater than the value specified.")
 	addSuffix           = flag.Bool("statsd.add-suffix", true, "Add the metric type (counter/gauge/timer) as suffix to the generated Prometheus metric (NOT recommended, but set by default for backward compatibility).")
 	showVersion         = flag.Bool("version", false, "Print version information.")
+	dropUnmapped        = flag.Bool("statsd.drop-unmapped", false, "Drop statsd metrics which have no matched mapping configured.")
 )
 
 func serveHTTP() {


### PR DESCRIPTION
* Adds `-statsd.drop-unmapped` cmdline flag which causes statsd metrics
  that don't match a mapping to be dropped. New flag defaults to "false"