### PR TITLE
Resolves #84 adds support for regex mappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,23 @@ mappings:
     job: "${1}_server"
 ```
 
+Another capability when using YAML configuration is the ability to define matches
+using raw regular expressions as opposed to the default globbing style of match.
+This may allow for pulling structured data from otherwise poorly named statsd
+metrics AND allow for more precise targetting of match rules. When no `match_type`
+paramter is specified the default value of `glob` will be assumed:
+```yaml
+mappings:
+- match: (.*)\.(.*)--(.*)\.status\.(.*)\.count
+  match_type: regex
+  labels:
+    name: "request_total"
+    hostname: "$1"
+    exec: "$2"
+    protocol: "$3"
+    code: "$4"
+```
+
 Note, that one may also set the histogram buckets.  If not set, then the default
 [Prometheus client values](https://godoc.org/github.com/prometheus/client_golang/prometheus#pkg-variables) are used: `[.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10]`. `+Inf` is added
 automatically.
@@ -177,13 +194,14 @@ automatically.
 only used when the statsd metric type is a timerand the `timer_type` is set to
 "histogram."
 
-One may also set defaults for the timer type and the buckets. These will be used
+One may also set defaults for the timer type, buckets and match_type. These will be used
 by all mappings that do not define these.
 
 ```yaml
 defaults:
   timer_type: histogram
   buckets: [.005, .01, .025, .05, .1, .25, .5, 1, 2.5 ]
+  match_type: glob
 mappings:
 # This will be a histogram using the buckets set in `defaults`.
 - match: test.timing.*.*.*

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ using raw regular expressions as opposed to the default globbing style of match.
 This may allow for pulling structured data from otherwise poorly named statsd
 metrics AND allow for more precise targetting of match rules. When no `match_type`
 paramter is specified the default value of `glob` will be assumed:
+
 ```yaml
 mappings:
 - match: (.*)\.(.*)--(.*)\.status\.(.*)\.count

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -219,6 +219,15 @@ mappings:
     second: "$2"
     third: "$3"
     job: "$1-$2-$3"
+- match: (.*)\.(.*)-(.*)\.(.*)
+  match_type: regex
+  labels:
+    name: "proxy_requests_total"
+    job: "$1"
+    protocol: "$2"
+    endpoint: "$3"
+    result: "$4"
+
   `,
 			mappings: map[string]map[string]string{
 				"test.dispatcher.FooProcessor.send.succeeded": map[string]string{
@@ -243,6 +252,13 @@ mappings:
 					"job":    "foo-bar-",
 				},
 				"foo.bar.baz": map[string]string{},
+				"proxy-1.http-goober.success": map[string]string{
+					"name":     "proxy_requests_total",
+					"job":      "proxy-1",
+					"protocol": "http",
+					"endpoint": "goober",
+					"result":   "success",
+				},
 			},
 		},
 		// Config with bad regex reference.
@@ -333,6 +349,17 @@ mappings:
 mappings:
 - match: test.*.*
   timer_type: wrong
+  labels:
+    name: "foo"
+    `,
+			configBad: true,
+		},
+		//Config with uncompilable regex.
+		{
+			config: `---
+mappings:
+- match: *\.foo
+  match_type: regex
   labels:
     name: "foo"
     `,

--- a/match.go
+++ b/match.go
@@ -35,7 +35,7 @@ func (t *matchType) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	case matchTypeGlob, matchTypeDefault:
 		*t = matchTypeGlob
 	default:
-		return fmt.Errorf("invalid match type '%s'", v)
+		return fmt.Errorf("invalid match type %q", v)
 	}
 	return nil
 }

--- a/match.go
+++ b/match.go
@@ -1,0 +1,41 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "fmt"
+
+type matchType string
+
+const (
+	matchTypeGlob    matchType = "glob"
+	matchTypeRegex   matchType = "regex"
+	matchTypeDefault matchType = ""
+)
+
+func (t *matchType) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var v string
+	if err := unmarshal(&v); err != nil {
+		return err
+	}
+
+	switch matchType(v) {
+	case matchTypeRegex:
+		*t = matchTypeRegex
+	case matchTypeGlob, matchTypeDefault:
+		*t = matchTypeGlob
+	default:
+		return fmt.Errorf("invalid match type '%s'", v)
+	}
+	return nil
+}


### PR DESCRIPTION
  * Added `regex` match_type as valid config callout in both individual mappers
    and mapper defaults
  * Added test coverage for changes
  * Updated documentation to reflect usage of `match_type` parameter and
    provide example of a raw regex match rule