### PR TITLE
Resolves #78 Allow help text to be customized

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,17 @@ mappings:
     job: "${1}_server"
 ```
 
+If the default metric help text is insufficient for your needs you may use the YAML
+configuration to specify a custom help text for each mapping:
+```yaml
+mappings:
+- match: http.request.*
+  help: "Total number of http requests"
+  labels:
+    name: "http_requests_total"
+    code: "$1"
+```
+
 Using the YAML configuration, one may also set the timer type to "histogram". The 
 default is "summary" as in the plain text configuration format.  For example,
 to set the timer type for a single metric:

--- a/exporter.go
+++ b/exporter.go
@@ -71,13 +71,19 @@ func NewCounterContainer() *CounterContainer {
 	}
 }
 
-func (c *CounterContainer) Get(metricName string, labels prometheus.Labels) (prometheus.Counter, error) {
+func (c *CounterContainer) Get(metricName string, labels prometheus.Labels, mapping *metricMapping) (prometheus.Counter, error) {
+	var help string
+	if mapping.HelpText == "" {
+		help = defaultHelp
+	} else {
+		help = mapping.HelpText
+	}
 	hash := hashNameAndLabels(metricName, labels)
 	counter, ok := c.Elements[hash]
 	if !ok {
 		counter = prometheus.NewCounter(prometheus.CounterOpts{
 			Name:        metricName,
-			Help:        defaultHelp,
+			Help:        help,
 			ConstLabels: labels,
 		})
 		if err := prometheus.Register(counter); err != nil {
@@ -98,13 +104,19 @@ func NewGaugeContainer() *GaugeContainer {
 	}
 }
 
-func (c *GaugeContainer) Get(metricName string, labels prometheus.Labels) (prometheus.Gauge, error) {
+func (c *GaugeContainer) Get(metricName string, labels prometheus.Labels, mapping *metricMapping) (prometheus.Gauge, error) {
+	var help string
+	if mapping.HelpText == "" {
+		help = defaultHelp
+	} else {
+		help = mapping.HelpText
+	}
 	hash := hashNameAndLabels(metricName, labels)
 	gauge, ok := c.Elements[hash]
 	if !ok {
 		gauge = prometheus.NewGauge(prometheus.GaugeOpts{
 			Name:        metricName,
-			Help:        defaultHelp,
+			Help:        help,
 			ConstLabels: labels,
 		})
 		if err := prometheus.Register(gauge); err != nil {
@@ -125,14 +137,20 @@ func NewSummaryContainer() *SummaryContainer {
 	}
 }
 
-func (c *SummaryContainer) Get(metricName string, labels prometheus.Labels) (prometheus.Summary, error) {
+func (c *SummaryContainer) Get(metricName string, labels prometheus.Labels, mapping *metricMapping) (prometheus.Summary, error) {
+	var help string
+	if mapping.HelpText == "" {
+		help = defaultHelp
+	} else {
+		help = mapping.HelpText
+	}
 	hash := hashNameAndLabels(metricName, labels)
 	summary, ok := c.Elements[hash]
 	if !ok {
 		summary = prometheus.NewSummary(
 			prometheus.SummaryOpts{
 				Name:        metricName,
-				Help:        defaultHelp,
+				Help:        help,
 				ConstLabels: labels,
 			})
 		if err := prometheus.Register(summary); err != nil {
@@ -156,6 +174,12 @@ func NewHistogramContainer(mapper *metricMapper) *HistogramContainer {
 }
 
 func (c *HistogramContainer) Get(metricName string, labels prometheus.Labels, mapping *metricMapping) (prometheus.Histogram, error) {
+	var help string
+	if mapping.HelpText == "" {
+		help = defaultHelp
+	} else {
+		help = mapping.HelpText
+	}
 	hash := hashNameAndLabels(metricName, labels)
 	histogram, ok := c.Elements[hash]
 	if !ok {
@@ -166,7 +190,7 @@ func (c *HistogramContainer) Get(metricName string, labels prometheus.Labels, ma
 		histogram = prometheus.NewHistogram(
 			prometheus.HistogramOpts{
 				Name:        metricName,
-				Help:        defaultHelp,
+				Help:        help,
 				ConstLabels: labels,
 				Buckets:     buckets,
 			})
@@ -281,6 +305,7 @@ func (b *Exporter) Listen(e <-chan Events) {
 				counter, err := b.Counters.Get(
 					b.suffix(metricName, "counter"),
 					prometheusLabels,
+					mapping,
 				)
 				if err == nil {
 					counter.Add(event.Value())
@@ -295,6 +320,7 @@ func (b *Exporter) Listen(e <-chan Events) {
 				gauge, err := b.Gauges.Get(
 					b.suffix(metricName, "gauge"),
 					prometheusLabels,
+					mapping,
 				)
 
 				if err == nil {
@@ -338,6 +364,7 @@ func (b *Exporter) Listen(e <-chan Events) {
 					summary, err := b.Summaries.Get(
 						b.suffix(metricName, "timer"),
 						prometheusLabels,
+						mapping,
 					)
 					if err == nil {
 						summary.Observe(event.Value())

--- a/mapper.go
+++ b/mapper.go
@@ -51,6 +51,7 @@ type metricMapping struct {
 	Labels    prometheus.Labels `yaml:"labels"`
 	TimerType timerType         `yaml:"timer_type"`
 	Buckets   []float64         `yaml:"buckets"`
+	HelpText  string            `yaml:"help"`
 }
 
 type configLoadStates int


### PR DESCRIPTION
  * Updated mappings to accept custom help text in YAML config
  * Updated exporter to display configured help messages
  * Update README to reflect aditional configurability