### PR TITLE
Resolves #78 Allow help text to be customized

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,17 @@ follows:
      => test_web__server_foo_bar{}
 
 
+If the default metric help text is insufficient for your needs you may use the YAML
+configuration to specify a custom help text for each mapping:
+```yaml
+mappings:
+- match: http.request.*
+  help: "Total number of http requests"
+  labels:
+    name: "http_requests_total"
+    code: "$1"
+```
+
 In the configuration, one may also set the timer type to "histogram". The 
 default is "summary" as in the plain text configuration format.  For example,
 to set the timer type for a single metric:

--- a/exporter.go
+++ b/exporter.go
@@ -273,7 +273,7 @@ func (b *Exporter) Listen(e <-chan Events) {
 
 			mapping, labels, present := b.mapper.getMapping(event.MetricName())
 			if mapping == nil {
-				mapping = &metricMapping{} // TODO - This satisfies an exporter_test, that test probably wants to be re-written
+				mapping = &metricMapping{}
 			}
 			if present {
 				metricName = labels["name"]

--- a/mapper.go
+++ b/mapper.go
@@ -55,13 +55,6 @@ type metricMapping struct {
 	HelpText  string            `yaml:"help"`
 }
 
-type configLoadStates int
-
-const (
-	SEARCHING configLoadStates = iota
-	METRIC_DEFINITION
-)
-
 func (m *metricMapper) initFromYAMLString(fileContents string) error {
 	var n metricMapper
 

--- a/mapper.go
+++ b/mapper.go
@@ -52,7 +52,15 @@ type metricMapping struct {
 	TimerType timerType         `yaml:"timer_type"`
 	Buckets   []float64         `yaml:"buckets"`
 	MatchType matchType         `yaml:"match_type"`
+	HelpText  string            `yaml:"help"`
 }
+
+type configLoadStates int
+
+const (
+	SEARCHING configLoadStates = iota
+	METRIC_DEFINITION
+)
 
 func (m *metricMapper) initFromYAMLString(fileContents string) error {
 	var n metricMapper


### PR DESCRIPTION
  * Updated mappings to accept custom help text in YAML config
  * Updated exporter to display configured help messages
  * Update README to reflect aditional configurability
  * Minor Update to exporter to allow tests to pass with mocked
    statsdlistener that has no mappers