### PR TITLE
Resolves #20 Allow for templated metric names

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -258,7 +258,7 @@ func (b *Exporter) Listen(e <-chan Events) {
 
 			mapping, labels, present := b.mapper.getMapping(event.MetricName())
 			if present {
-				metricName = labels["name"]
+				metricName = escapeMetricName(labels["name"])
 				for label, value := range labels {
 					if label != "name" {
 						prometheusLabels[label] = value

--- a/mapper.go
+++ b/mapper.go
@@ -144,12 +144,9 @@ func (m *metricMapper) initFromYAMLString(fileContents string) error {
 		}
 
 		// Check that label is correct.
-		for k, v := range currentMapping.Labels {
+		for k := range currentMapping.Labels {
 			if !metricNameRE.MatchString(k) {
 				return fmt.Errorf("invalid label key: %s", k)
-			}
-			if k == "name" && !metricNameRE.MatchString(v) {
-				return fmt.Errorf("metric name '%s' doesn't match regex '%s'", v, metricNameRE)
 			}
 		}
 

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -287,16 +287,6 @@ mappings:
   `,
 			configBad: true,
 		},
-		// Config with bad metric name.
-		{
-			config: `---
-mappings:
-- match: test.*.*
-  labels:
-    name: "0foo"
-  `,
-			configBad: true,
-		},
 		// Config with no metric name.
 		{
 			config: `---


### PR DESCRIPTION
  * Removed field validation for "name" label
  * Updated tests to match
  * Wraped metric names in escape logic in exporter

I suppose this should probably have a bit of a discussion. Due to the way the code works enabling templating in in the name label of a mapping only required removing a regex validator that checked that the name label was a valid prometheus metric name. Since you can't validate a template until it is expanded it makes sense that we wouldn't have the additionally validation on this parameter. So as an alternative I've just wrapped the name of even mapped metrics with `escapeMetricName` to ensure the final name is valid.

Additionally, there is the caveat that once the full metric definition and labels are dynamic there are myriad of way to get unanticipated metric namespace collisions. For instance it is possible to end up with the same metric with two different label sets which the prometheus exporter library won't allow. There was some effort in #74 to replace the stock registry from the prometheus go exporter with a more permissive registry; this would probably make sense (IMHO) as it would definitely allow for an easier migration from statsd to prometheus. However the registry code in #74 is still quite rough.

TLDR; this allows dynamic metric names, flexibility isn't free, shooting yourself in the foot becomes easier.