### PR TITLE
Resolves #81 - Reduce log levels

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -275,6 +275,7 @@ func (b *Exporter) Listen(e <-chan Events) {
 				// will cause the exporter to panic. Instead we will warn and continue to the next event.
 				if event.Value() < 0.0 {
 					log.Debugf("Counter %q is: '%f' (counter must be non-negative value)", metricName, event.Value())
+					eventStats.WithLabelValues("illegal_negative_counter").Inc()
 					continue
 				}
 

--- a/exporter.go
+++ b/exporter.go
@@ -274,7 +274,7 @@ func (b *Exporter) Listen(e <-chan Events) {
 				// We don't accept negative values for counters. Incrementing the counter with a negative number
 				// will cause the exporter to panic. Instead we will warn and continue to the next event.
 				if event.Value() < 0.0 {
-					log.Errorf("Counter %q is: '%f' (counter must be non-negative value)", metricName, event.Value())
+					log.Debugf("Counter %q is: '%f' (counter must be non-negative value)", metricName, event.Value())
 					continue
 				}
 
@@ -287,7 +287,7 @@ func (b *Exporter) Listen(e <-chan Events) {
 
 					eventStats.WithLabelValues("counter").Inc()
 				} else {
-					log.Errorf(regErrF, metricName, err)
+					log.Debugf(regErrF, metricName, err)
 					conflictingEventStats.WithLabelValues("counter").Inc()
 				}
 
@@ -306,7 +306,7 @@ func (b *Exporter) Listen(e <-chan Events) {
 
 					eventStats.WithLabelValues("gauge").Inc()
 				} else {
-					log.Errorf(regErrF, metricName, err)
+					log.Debugf(regErrF, metricName, err)
 					conflictingEventStats.WithLabelValues("gauge").Inc()
 				}
 
@@ -330,7 +330,7 @@ func (b *Exporter) Listen(e <-chan Events) {
 						histogram.Observe(event.Value())
 						eventStats.WithLabelValues("timer").Inc()
 					} else {
-						log.Errorf(regErrF, metricName, err)
+						log.Debugf(regErrF, metricName, err)
 						conflictingEventStats.WithLabelValues("timer").Inc()
 					}
 
@@ -343,7 +343,7 @@ func (b *Exporter) Listen(e <-chan Events) {
 						summary.Observe(event.Value())
 						eventStats.WithLabelValues("timer").Inc()
 					} else {
-						log.Errorf(regErrF, metricName, err)
+						log.Debugf(regErrF, metricName, err)
 						conflictingEventStats.WithLabelValues("timer").Inc()
 					}
 
@@ -352,7 +352,7 @@ func (b *Exporter) Listen(e <-chan Events) {
 				}
 
 			default:
-				log.Errorln("Unsupported event type")
+				log.Debugln("Unsupported event type")
 				eventStats.WithLabelValues("illegal").Inc()
 			}
 		}
@@ -408,7 +408,7 @@ func parseDogStatsDTagsToLabels(component string) map[string]string {
 
 		if len(kv) < 2 || len(kv[1]) == 0 {
 			networkStats.WithLabelValues("malformed_dogstatsd_tag").Inc()
-			log.Errorf("Malformed or empty DogStatsD tag %s in component %s", t, component)
+			log.Debugf("Malformed or empty DogStatsD tag %s in component %s", t, component)
 			continue
 		}
 
@@ -426,7 +426,7 @@ func lineToEvents(line string) Events {
 	elements := strings.SplitN(line, ":", 2)
 	if len(elements) < 2 || len(elements[0]) == 0 || !utf8.ValidString(line) {
 		networkStats.WithLabelValues("malformed_line").Inc()
-		log.Errorln("Bad line from StatsD:", line)
+		log.Debugln("Bad line from StatsD:", line)
 		return events
 	}
 	metric := elements[0]
@@ -443,7 +443,7 @@ samples:
 		samplingFactor := 1.0
 		if len(components) < 2 || len(components) > 4 {
 			networkStats.WithLabelValues("malformed_component").Inc()
-			log.Errorln("Bad component on line:", line)
+			log.Debugln("Bad component on line:", line)
 			continue
 		}
 		valueStr, statType := components[0], components[1]
@@ -455,7 +455,7 @@ samples:
 
 		value, err := strconv.ParseFloat(valueStr, 64)
 		if err != nil {
-			log.Errorf("Bad value %s on line: %s", valueStr, line)
+			log.Debugf("Bad value %s on line: %s", valueStr, line)
 			networkStats.WithLabelValues("malformed_value").Inc()
 			continue
 		}
@@ -465,7 +465,7 @@ samples:
 		if len(components) >= 3 {
 			for _, component := range components[2:] {
 				if len(component) == 0 {
-					log.Errorln("Empty component on line: ", line)
+					log.Debugln("Empty component on line: ", line)
 					networkStats.WithLabelValues("malformed_component").Inc()
 					continue samples
 				}
@@ -475,13 +475,13 @@ samples:
 				switch component[0] {
 				case '@':
 					if statType != "c" && statType != "ms" {
-						log.Errorln("Illegal sampling factor for non-counter metric on line", line)
+						log.Debugln("Illegal sampling factor for non-counter metric on line", line)
 						networkStats.WithLabelValues("illegal_sample_factor").Inc()
 						continue
 					}
 					samplingFactor, err = strconv.ParseFloat(component[1:], 64)
 					if err != nil {
-						log.Errorf("Invalid sampling factor %s on line %s", component[1:], line)
+						log.Debugf("Invalid sampling factor %s on line %s", component[1:], line)
 						networkStats.WithLabelValues("invalid_sample_factor").Inc()
 					}
 					if samplingFactor == 0 {
@@ -496,7 +496,7 @@ samples:
 				case '#':
 					labels = parseDogStatsDTagsToLabels(component)
 				default:
-					log.Errorf("Invalid sampling factor or tag section %s on line %s", components[2], line)
+					log.Debugf("Invalid sampling factor or tag section %s on line %s", components[2], line)
 					networkStats.WithLabelValues("invalid_sample_factor").Inc()
 					continue
 				}
@@ -506,7 +506,7 @@ samples:
 		for i := 0; i < multiplyEvents; i++ {
 			event, err := buildEvent(statType, metric, value, relative, labels)
 			if err != nil {
-				log.Errorf("Error building event on line %s: %s", line, err)
+				log.Debugf("Error building event on line %s: %s", line, err)
 				networkStats.WithLabelValues("illegal_event").Inc()
 				continue
 			}
@@ -564,13 +564,13 @@ func (l *StatsDTCPListener) handleConn(c *net.TCPConn, e chan<- Events) {
 		if err != nil {
 			if err != io.EOF {
 				networkStats.WithLabelValues("tcp_error").Inc()
-				log.Errorf("Read %s failed: %v", c.RemoteAddr(), err)
+				log.Debugf("Read %s failed: %v", c.RemoteAddr(), err)
 			}
 			break
 		}
 		if isPrefix {
 			networkStats.WithLabelValues("tcp_line_too_long").Inc()
-			log.Errorf("Read %s failed: line too long", c.RemoteAddr())
+			log.Debugf("Read %s failed: line too long", c.RemoteAddr())
 			break
 		}
 		e <- lineToEvents(string(line))


### PR DESCRIPTION
* Reduced all `log.Error*` events to `log.Debug*` in `exporter.go` where
  an existing internal metric tracks the event.