### PR TITLE
Removes `-statsd.add-suffix` option flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ without values (`#some_tag`) are not supported.
             If set use a syslog logger or JSON logging. Example: logger:syslog?appname=bob&local=7 or logger:stdout?json=true. Defaults to stderr.
       -log.level value
             Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal].
-      -statsd.add-suffix
-            Add the metric type (counter/gauge/timer) as suffix to the generated Prometheus metric (NOT recommended, but set by default for backward compatibility). (default true)
       -statsd.listen-address string
             The UDP address on which to receive statsd metric lines. DEPRECATED, use statsd.listen-udp instead.
       -statsd.listen-tcp string
@@ -98,13 +96,7 @@ In general, the different metric types are translated as follows:
                    -> Prometheus counter (suffix `_total`)  <-- indicates total time spent
                    -> Prometheus counter (suffix `_count`)  <-- indicates total number of timer events
 
-If `-statsd.add-suffix` is set, the exporter appends the metric type (`_gauge`,
-`_counter`, `_timer`) to the resulting metrics. This is enabled by default for
-backward compatibility but discouraged to use. Instead, it is better to
-explicitly define the full metric name in your mapping and run the exporter
-with `-statsd.add-suffix=false`.
-
-An example mapping configuration with `-statsd.add-suffix=false`:
+An example mapping configuration:
 
     # comments are allowed
     test.dispatcher.*.*.*

--- a/exporter.go
+++ b/exporter.go
@@ -223,7 +223,6 @@ type Exporter struct {
 	Summaries  *SummaryContainer
 	Histograms *HistogramContainer
 	mapper     *metricMapper
-	addSuffix  bool
 }
 
 func escapeMetricName(metricName string) string {
@@ -235,14 +234,6 @@ func escapeMetricName(metricName string) string {
 	// Replace all illegal metric chars with underscores.
 	metricName = illegalCharsRE.ReplaceAllString(metricName, "_")
 	return metricName
-}
-
-func (b *Exporter) suffix(metricName, suffix string) string {
-	str := metricName
-	if b.addSuffix {
-		str += "_" + suffix
-	}
-	return str
 }
 
 func (b *Exporter) Listen(e <-chan Events) {
@@ -280,7 +271,7 @@ func (b *Exporter) Listen(e <-chan Events) {
 				}
 
 				counter, err := b.Counters.Get(
-					b.suffix(metricName, "counter"),
+					metricName,
 					prometheusLabels,
 				)
 				if err == nil {
@@ -294,7 +285,7 @@ func (b *Exporter) Listen(e <-chan Events) {
 
 			case *GaugeEvent:
 				gauge, err := b.Gauges.Get(
-					b.suffix(metricName, "gauge"),
+					metricName,
 					prometheusLabels,
 				)
 
@@ -323,7 +314,7 @@ func (b *Exporter) Listen(e <-chan Events) {
 				switch t {
 				case timerTypeHistogram:
 					histogram, err := b.Histograms.Get(
-						b.suffix(metricName, "timer"),
+						metricName,
 						prometheusLabels,
 						mapping,
 					)
@@ -337,7 +328,7 @@ func (b *Exporter) Listen(e <-chan Events) {
 
 				case timerTypeDefault, timerTypeSummary:
 					summary, err := b.Summaries.Get(
-						b.suffix(metricName, "timer"),
+						metricName,
 						prometheusLabels,
 					)
 					if err == nil {
@@ -360,9 +351,8 @@ func (b *Exporter) Listen(e <-chan Events) {
 	}
 }
 
-func NewExporter(mapper *metricMapper, addSuffix bool) *Exporter {
+func NewExporter(mapper *metricMapper) *Exporter {
 	return &Exporter{
-		addSuffix:  addSuffix,
 		Counters:   NewCounterContainer(),
 		Gauges:     NewGaugeContainer(),
 		Summaries:  NewSummaryContainer(),

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -44,7 +44,7 @@ func TestNegativeCounter(t *testing.T) {
 		},
 	}
 	events <- c
-	ex := NewExporter(&metricMapper{}, true)
+	ex := NewExporter(&metricMapper{})
 
 	// Close channel to signify we are done with the listener after a short period.
 	go func() {
@@ -60,7 +60,7 @@ func TestNegativeCounter(t *testing.T) {
 // It sends the same tags first with a valid value, then with an invalid one.
 // The exporter should not panic, but drop the invalid event
 func TestInvalidUtf8InDatadogTagValue(t *testing.T) {
-	ex := NewExporter(&metricMapper{}, true)
+	ex := NewExporter(&metricMapper{})
 	for _, l := range []statsDPacketHandler{&StatsDUDPListener{}, &mockStatsDTCPListener{}} {
 		events := make(chan Events, 2)
 
@@ -96,7 +96,7 @@ func TestHistogramUnits(t *testing.T) {
 		},
 	}
 	events <- c
-	ex := NewExporter(&metricMapper{}, true)
+	ex := NewExporter(&metricMapper{})
 	ex.mapper.Defaults.TimerType = timerTypeHistogram
 
 	// Close channel to signify we are done with the listener after a short period.
@@ -105,7 +105,7 @@ func TestHistogramUnits(t *testing.T) {
 		close(events)
 	}()
 	mock := &MockHistogram{}
-	key := hashNameAndLabels(name+"_timer", nil)
+	key := hashNameAndLabels(name, nil)
 	ex.Histograms.Elements[key] = mock
 	ex.Listen(events)
 	if mock.value == 300 {

--- a/main.go
+++ b/main.go
@@ -39,7 +39,6 @@ var (
 	statsdListenTCP     = flag.String("statsd.listen-tcp", ":9125", "The TCP address on which to receive statsd metric lines. \"\" disables it.")
 	mappingConfig       = flag.String("statsd.mapping-config", "", "Metric mapping configuration file name.")
 	readBuffer          = flag.Int("statsd.read-buffer", 0, "Size (in bytes) of the operating system's transmit read buffer associated with the UDP connection. Please make sure the kernel parameters net.core.rmem_max is set to a value greater than the value specified.")
-	addSuffix           = flag.Bool("statsd.add-suffix", true, "Add the metric type (counter/gauge/timer) as suffix to the generated Prometheus metric (NOT recommended, but set by default for backward compatibility).")
 	showVersion         = flag.Bool("version", false, "Print version information.")
 )
 
@@ -147,10 +146,6 @@ func main() {
 		log.Fatalln("At least one of UDP/TCP listeners must be specified.")
 	}
 
-	if *addSuffix {
-		log.Warnln("Warning: Using -statsd.add-suffix is discouraged. We recommend explicitly naming metrics appropriately in the mapping configuration.")
-	}
-
 	log.Infoln("Starting StatsD -> Prometheus Exporter", version.Info())
 	log.Infoln("Build context", version.BuildContext())
 	log.Infof("Accepting StatsD Traffic: UDP %v, TCP %v", *statsdListenUDP, *statsdListenTCP)
@@ -199,6 +194,6 @@ func main() {
 		}
 		go watchConfig(*mappingConfig, mapper)
 	}
-	exporter := NewExporter(mapper, *addSuffix)
+	exporter := NewExporter(mapper)
 	exporter.Listen(events)
 }


### PR DESCRIPTION
As mentioned in discussion on #77 this flag has been deprecated in spirit by the documentation's strong recommendation against using it. Additionally there is a strong distaste for having global boolean flags.

* Remove option flag
* Update NewExporter call signature to not take suffix boolean
* Update tests to reflect new behavior and signature
* Update documentation to reflect option flag removal