### PR TITLE
Fix TravisCI tests: Force IPv4 for the mock TCP listener

### DIFF
--- a/exporter_test.go
+++ b/exporter_test.go
@@ -124,7 +124,9 @@ type mockStatsDTCPListener struct {
 }
 
 func (ml *mockStatsDTCPListener) handlePacket(packet []byte, e chan<- Events) {
-	lc, err := net.ListenTCP("tcp", nil)
+	// Forcing IPv4 because the TravisCI build environment does not have IPv6
+	// addresses.
+	lc, err := net.ListenTCP("tcp4", nil)
 	if err != nil {
 		panic(fmt.Sprintf("mockStatsDTCPListener: listen failed: %v", err))
 	}


### PR DESCRIPTION
Travis CI [does not have IPv6][0] in any environment. It could be
[enabled][1] if we ran the build in a VM, but that is much slower to
start. Instead, we just force the test connection to use IPv4.

[0]: https://blog.travis-ci.com/2015-11-27-moving-to-a-more-elastic-future#ipv6-no-longer-present
[1]: travis-ci/travis-ci#5200 (comment)
