### PR TITLE
Avoid regex panic

### DIFF
--- a/mapper.go
+++ b/mapper.go
@@ -106,9 +106,17 @@ func (m *metricMapper) initFromYAMLString(fileContents string) error {
 			// can use to match metrics later on.
 			metricRe := strings.Replace(currentMapping.Match, ".", "\\.", -1)
 			metricRe = strings.Replace(metricRe, "*", "([^.]*)", -1)
-			currentMapping.regex = regexp.MustCompile("^" + metricRe + "$")
+			if regex, err := regexp.Compile("^" + metricRe + "$"); err != nil {
+				return fmt.Errorf("invalid match %s. cannot compile regex in mapping: %v", currentMapping.Match, err)
+			} else {
+				currentMapping.regex = regex
+			}
 		} else {
-			currentMapping.regex = regexp.MustCompile(currentMapping.Match)
+			if regex, err := regexp.Compile(currentMapping.Match); err != nil {
+				return fmt.Errorf("invalid regex %s in mapping: %v", currentMapping.Match, err)
+			} else {
+				currentMapping.regex = regex
+			}
 		}
 
 		if currentMapping.TimerType == "" {

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -310,7 +310,7 @@ mappings:
 		{
 			config: `---
 mappings:
-- match: "*\.foo"
+- match: "*\\.foo"
   match_type: regex
   name: "foo"
   labels: {}


### PR DESCRIPTION
Fix the test for bad regexes:

This test did not fail because the regex was bad, it failed because yaml
parsing failed.

This fixes the yaml which uncovers a panic in initFromYAMLString.

Avoid panic from compiling user supplied regex:

If an invalid regex is supplied mustCompile would panic during
configuration reload. Return an error instead that can be handled.