### PR TITLE
feat: configurable quantiles for Summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,32 @@ mappings:
     code: "$1"
 ```
 
+By default, statsd timers are represented as a Prometheus summary with
+quantiles. You may optionally configure the [quantiles and acceptable
+error](https://prometheus.io/docs/practices/histograms/#quantiles):
+
+```yaml
+mappings:
+- match: test.timing.*.*.*
+  timer_type: summary
+  name: "my_timer"
+  labels:
+    provider: "$2"
+    outcome: "$3"
+    job: "${1}_server"
+  quantiles:
+    - quantile: 0.99
+      error: 0.001
+    - quantile: 0.95
+      error: 0.01
+    - quantile: 0.9
+      error: 0.05
+    - quantile: 0.5
+      error: 0.005
+```
+
+The default quantiles are 0.99, 0.9, and 0.5.
+
 In the configuration, one may also set the timer type to "histogram". The
 default is "summary" as in the plain text configuration format.  For example,
 to set the timer type for a single metric:
@@ -176,15 +202,6 @@ mappings:
     provider: "$2"
     outcome: "$3"
     job: "${1}_server"
-  quantiles:           # Optionally configure quantiles for your summaries
-    - quantile: 0.99   # https://prometheus.io/docs/practices/histograms/#quantiles
-      error: 0.001
-    - quantile: 0.95
-      error: 0.01
-    - quantile: 0.9
-      error: 0.05
-    - quantile: 0.5
-      error: 0.005
 ```
 
 Another capability when using YAML configuration is the ability to define matches
@@ -213,7 +230,7 @@ automatically.
 only used when the statsd metric type is a timerand the `timer_type` is set to
 "histogram."
 
-One may also set defaults for the timer type, buckets and match_type. These will be used
+One may also set defaults for the timer type, buckets or quantiles, and match_type. These will be used
 by all mappings that do not define these.
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -176,6 +176,15 @@ mappings:
     provider: "$2"
     outcome: "$3"
     job: "${1}_server"
+  quantiles:           # Optionally configure quantiles for your summaries
+    - quantile: 0.99   # https://prometheus.io/docs/practices/histograms/#quantiles
+      error: 0.001
+    - quantile: 0.95
+      error: 0.01
+    - quantile: 0.9
+      error: 0.05
+    - quantile: 0.5
+      error: 0.005
 ```
 
 Another capability when using YAML configuration is the ability to define matches

--- a/mapper.go
+++ b/mapper.go
@@ -34,9 +34,10 @@ var (
 )
 
 type mapperConfigDefaults struct {
-	TimerType timerType `yaml:"timer_type"`
-	Buckets   []float64 `yaml:"buckets"`
-	MatchType matchType `yaml:"match_type"`
+	TimerType timerType         `yaml:"timer_type"`
+	Buckets   []float64         `yaml:"buckets"`
+	Quantiles []metricObjective `yaml:"quantiles"`
+	MatchType matchType         `yaml:"match_type"`
 }
 
 type metricMapper struct {
@@ -54,10 +55,22 @@ type metricMapping struct {
 	Labels          prometheus.Labels `yaml:"labels"`
 	TimerType       timerType         `yaml:"timer_type"`
 	Buckets         []float64         `yaml:"buckets"`
+	Quantiles       []metricObjective `yaml:"quantiles"`
 	MatchType       matchType         `yaml:"match_type"`
 	HelpText        string            `yaml:"help"`
 	Action          actionType        `yaml:"action"`
 	MatchMetricType metricType        `yaml:"match_metric_type"`
+}
+
+type metricObjective struct {
+	Quantile float64 `yaml:"quantile"`
+	Error    float64 `yaml:"error"`
+}
+
+var defaultQuantiles = []metricObjective{
+	{Quantile: 0.5, Error: 0.05},
+	{Quantile: 0.9, Error: 0.01},
+	{Quantile: 0.99, Error: 0.001},
 }
 
 func (m *metricMapper) initFromYAMLString(fileContents string) error {
@@ -69,6 +82,10 @@ func (m *metricMapper) initFromYAMLString(fileContents string) error {
 
 	if n.Defaults.Buckets == nil || len(n.Defaults.Buckets) == 0 {
 		n.Defaults.Buckets = prometheus.DefBuckets
+	}
+
+	if n.Defaults.Quantiles == nil || len(n.Defaults.Quantiles) == 0 {
+		n.Defaults.Quantiles = defaultQuantiles
 	}
 
 	if n.Defaults.MatchType == matchTypeDefault {
@@ -128,6 +145,10 @@ func (m *metricMapper) initFromYAMLString(fileContents string) error {
 
 		if currentMapping.Buckets == nil || len(currentMapping.Buckets) == 0 {
 			currentMapping.Buckets = n.Defaults.Buckets
+		}
+
+		if currentMapping.Quantiles == nil || len(currentMapping.Quantiles) == 0 {
+			currentMapping.Quantiles = n.Defaults.Quantiles
 		}
 
 	}


### PR DESCRIPTION
* Quantile values for a Summary are now configurable.

* The default quantiles (DefObjectives) in the Prometheus Go client library is
deprecated. This commit removes the reliance on it.