### PR TITLE
Label conflicting events by event name

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -310,7 +310,7 @@ func (b *Exporter) Listen(e <-chan Events) {
 					eventStats.WithLabelValues("counter").Inc()
 				} else {
 					log.Debugf(regErrF, metricName, err)
-					conflictingEventStats.WithLabelValues("counter").Inc()
+					conflictingEventStats.WithLabelValues("counter", metricName).Inc()
 				}
 
 			case *GaugeEvent:
@@ -330,7 +330,7 @@ func (b *Exporter) Listen(e <-chan Events) {
 					eventStats.WithLabelValues("gauge").Inc()
 				} else {
 					log.Debugf(regErrF, metricName, err)
-					conflictingEventStats.WithLabelValues("gauge").Inc()
+					conflictingEventStats.WithLabelValues("gauge", metricName).Inc()
 				}
 
 			case *TimerEvent:
@@ -355,7 +355,7 @@ func (b *Exporter) Listen(e <-chan Events) {
 						eventStats.WithLabelValues("timer").Inc()
 					} else {
 						log.Debugf(regErrF, metricName, err)
-						conflictingEventStats.WithLabelValues("timer").Inc()
+						conflictingEventStats.WithLabelValues("timer", metricName).Inc()
 					}
 
 				case mapper.TimerTypeDefault, mapper.TimerTypeSummary:
@@ -370,7 +370,7 @@ func (b *Exporter) Listen(e <-chan Events) {
 						eventStats.WithLabelValues("timer").Inc()
 					} else {
 						log.Debugf(regErrF, metricName, err)
-						conflictingEventStats.WithLabelValues("timer").Inc()
+						conflictingEventStats.WithLabelValues("timer", metricName).Inc()
 					}
 
 				default:

--- a/telemetry.go
+++ b/telemetry.go
@@ -81,7 +81,7 @@ var (
 	tagErrors = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "statsd_exporter_tag_errors_total",
-			Help: "The number of errors parsign DogStatsD tags.",
+			Help: "The number of errors parsing DogStatsD tags.",
 		},
 	)
 	configLoads = prometheus.NewCounterVec(
@@ -100,7 +100,7 @@ var (
 			Name: "statsd_exporter_events_conflict_total",
 			Help: "The total number of StatsD events with conflicting names.",
 		},
-		[]string{"type"},
+		[]string{"type", "event_name"},
 	)
 )
 


### PR DESCRIPTION
This should help diagnose _which_ events are conflicting, at the expense of increasing cardinality. My intuition is that relatively small sets of event names should end up conflicting over time.