### PR TITLE
Use maintainer label in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM        quay.io/prometheus/busybox:latest
-MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
+FROM  quay.io/prometheus/busybox:latest
+LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
 COPY statsd_exporter /bin/statsd_exporter
 


### PR DESCRIPTION
fixes #149.

Signed-off-by: Matthias Rampke <mr@soundcloud.com>