### PR TITLE
Add 'ip' label containing the IP of the reporter

### DIFF
--- a/bridge_test.go
+++ b/bridge_test.go
@@ -288,6 +288,7 @@ func TestHandlePacket(t *testing.T) {
 			}
 
 			for j, expected := range scenario.out {
+				delete(actual[j].Labels(), "ip")
 				if !reflect.DeepEqual(&expected, &actual[j]) {
 					t.Fatalf("%d.%d.%d. Expected %#v, got %#v in scenario '%s'", k, i, j, expected, actual[j], scenario.name)
 				}


### PR DESCRIPTION
Without the IP, reports from multiple sources override each other. 
Probably needs some configuration - but not familiar enough with the codebase, hopefully someone can 
take this over. I'm using this in Istio to identify reports from different envoys.