### PR TITLE
Remove stale metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ defaults:
   buckets: [.005, .01, .025, .05, .1, .25, .5, 1, 2.5 ]
   match_type: glob
   glob_disable_ordering: false
+  ttl: 0 # metrics not expired
 mappings:
 # This will be a histogram using the buckets set in `defaults`.
 - match: test.timing.*.*.*
@@ -349,6 +350,18 @@ mappings:
 ```
 
 Possible values for `match_metric_type` are `gauge`, `counter` and `timer`.
+
+### Time series expiration
+
+`ttl` parameter can be used to define expiration time for stale metrics.
+Value is a time duration with valid time units: "ns", "us" (or "µs"),
+"ms", "s", "m", "h". For example, `ttl: 1m20s`. `0` value is used to indicate
+not expired metrics.
+
+Expiration is useful to gather metrics with changing label values from
+dynamic environments like Kubernetes. For example, metric
+`ingress_nginx_upstream_retries_count` with label `pod` and
+changing pod name as a value for this label.
 
 ## Using Docker
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ defaults:
   buckets: [.005, .01, .025, .05, .1, .25, .5, 1, 2.5 ]
   match_type: glob
   glob_disable_ordering: false
-  ttl: 0 # metrics not expired
+  ttl: 0 # metrics do not expire
 mappings:
 # This will be a histogram using the buckets set in `defaults`.
 - match: test.timing.*.*.*
@@ -353,15 +353,15 @@ Possible values for `match_metric_type` are `gauge`, `counter` and `timer`.
 
 ### Time series expiration
 
-`ttl` parameter can be used to define expiration time for stale metrics.
-Value is a time duration with valid time units: "ns", "us" (or "µs"),
+The `ttl` parameter can be used to define the expiration time for stale metrics.
+The value is a time duration with valid time units: "ns", "us" (or "µs"),
 "ms", "s", "m", "h". For example, `ttl: 1m20s`. `0` value is used to indicate
-not expired metrics.
+metrics that do not expire.
 
-Expiration is useful to gather metrics with changing label values from
-dynamic environments like Kubernetes. For example, metric
-`ingress_nginx_upstream_retries_count` with label `pod` and
-changing pod name as a value for this label.
+ TTLs are applied to each mapped metric name/labels combination whenever
+ new samples are received. This means that you cannot immediately expire a
+ metric only by changing the mapping configuration. At least one sample must
+ be received for updated mappings to take effect.
 
 ## Using Docker
 

--- a/exporter.go
+++ b/exporter.go
@@ -50,7 +50,7 @@ var (
 	intBuf = make([]byte, 8)
 )
 
-func labelsNames(labels prometheus.Labels) []string {
+func labelNames(labels prometheus.Labels) []string {
 	names := make([]string, 0, len(labels))
 	for labelName := range labels {
 		names = append(names, labelName)
@@ -91,7 +91,7 @@ func (c *CounterContainer) Get(metricName string, labels prometheus.Labels, help
 		counterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: metricName,
 			Help: help,
-		}, labelsNames(labels))
+		}, labelNames(labels))
 		if err := prometheus.Register(counterVec); err != nil {
 			return nil, err
 		}
@@ -122,7 +122,7 @@ func (c *GaugeContainer) Get(metricName string, labels prometheus.Labels, help s
 		gaugeVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: metricName,
 			Help: help,
-		}, labelsNames(labels))
+		}, labelNames(labels))
 		if err := prometheus.Register(gaugeVec); err != nil {
 			return nil, err
 		}
@@ -165,7 +165,7 @@ func (c *SummaryContainer) Get(metricName string, labels prometheus.Labels, help
 				Name:       metricName,
 				Help:       help,
 				Objectives: objectives,
-			}, labelsNames(labels))
+			}, labelNames(labels))
 		if err := prometheus.Register(summaryVec); err != nil {
 			return nil, err
 		}
@@ -204,7 +204,7 @@ func (c *HistogramContainer) Get(metricName string, labels prometheus.Labels, he
 				Name:    metricName,
 				Help:    help,
 				Buckets: buckets,
-			}, labelsNames(labels))
+			}, labelNames(labels))
 		if err := prometheus.Register(histogramVec); err != nil {
 			return nil, err
 		}

--- a/exporter.go
+++ b/exporter.go
@@ -32,6 +32,7 @@ import (
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/model"
 
+	"github.com/prometheus/statsd_exporter/pkg/clock"
 	"github.com/prometheus/statsd_exporter/pkg/mapper"
 )
 
@@ -291,7 +292,7 @@ func escapeMetricName(metricName string) string {
 // Listen handles all events sent to the given channel sequentially. It
 // terminates when the channel is closed.
 func (b *Exporter) Listen(e <-chan Events) {
-	removeStaleMetricsTicker := time.NewTicker(time.Second)
+	removeStaleMetricsTicker := clock.NewTicker(time.Second)
 
 	for {
 		select {
@@ -439,7 +440,7 @@ func (b *Exporter) handleEvent(event Event) {
 
 // removeStaleMetrics removes label values set from metric with stale values
 func (b *Exporter) removeStaleMetrics() {
-	now := time.Now()
+	now := clock.Now()
 	// delete timeseries with expired ttl
 	for metricName := range b.labelValues {
 		for hash, lvs := range b.labelValues[metricName] {
@@ -473,7 +474,7 @@ func (b *Exporter) saveLabelValues(metricName string, labels prometheus.Labels, 
 		}
 		b.labelValues[metricName][hash] = metricLabelValues
 	}
-	now := time.Now()
+	now := clock.Now()
 	metricLabelValues.lastRegisteredAt = now
 	// Update ttl from mapping
 	metricLabelValues.ttl = ttl

--- a/exporter.go
+++ b/exporter.go
@@ -457,7 +457,7 @@ func (b *Exporter) removeStaleMetrics() {
 	}
 }
 
-// saveLabelValues stores label values set to labelValues and update lastRegisteredAt time
+// saveLabelValues stores label values set to labelValues and update lastRegisteredAt time and ttl value
 func (b *Exporter) saveLabelValues(metricName string, labels prometheus.Labels, ttl time.Duration) {
 	_, hasMetric := b.labelValues[metricName]
 	if !hasMetric {
@@ -473,6 +473,8 @@ func (b *Exporter) saveLabelValues(metricName string, labels prometheus.Labels, 
 	}
 	now := time.Now()
 	b.labelValues[metricName][hash].lastRegisteredAt = now
+	// Update ttl from mapping
+	b.labelValues[metricName][hash].ttl = ttl
 }
 
 func NewExporter(mapper *mapper.MetricMapper) *Exporter {

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/onsi/gomega v1.4.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v0.9.2
+	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910
 	github.com/prometheus/common v0.0.0-20181126121408-4724e9255275
 	github.com/sergi/go-diff v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.0.3 // indirect

--- a/pkg/clock/clock.go
+++ b/pkg/clock/clock.go
@@ -1,0 +1,28 @@
+package clock
+
+import (
+	"time"
+)
+
+var ClockInstance *Clock
+
+type Clock struct {
+	Instant  time.Time
+	TickerCh chan time.Time
+}
+
+func Now() time.Time {
+	if ClockInstance == nil {
+		return time.Now()
+	}
+	return ClockInstance.Instant
+}
+
+func NewTicker(d time.Duration) *time.Ticker {
+	if ClockInstance == nil || ClockInstance.TickerCh == nil {
+		return time.NewTicker(d)
+	}
+	return &time.Ticker{
+		C: ClockInstance.TickerCh,
+	}
+}

--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/statsd_exporter/pkg/mapper/fsm"
 	yaml "gopkg.in/yaml.v2"
+	"time"
 )
 
 var (
@@ -39,7 +40,7 @@ type mapperConfigDefaults struct {
 	Quantiles           []metricObjective `yaml:"quantiles"`
 	MatchType           MatchType         `yaml:"match_type"`
 	GlobDisableOrdering bool              `yaml:"glob_disable_ordering"`
-	Ttl                 uint64            `yaml:"ttl"`
+	Ttl                 time.Duration     `yaml:"ttl"`
 }
 
 type MetricMapper struct {
@@ -70,7 +71,7 @@ type MetricMapping struct {
 	HelpText        string            `yaml:"help"`
 	Action          ActionType        `yaml:"action"`
 	MatchMetricType MetricType        `yaml:"match_metric_type"`
-	Ttl             uint64            `yaml:"ttl"`
+	Ttl             time.Duration     `yaml:"ttl"`
 }
 
 type metricObjective struct {

--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -39,6 +39,7 @@ type mapperConfigDefaults struct {
 	Quantiles           []metricObjective `yaml:"quantiles"`
 	MatchType           MatchType         `yaml:"match_type"`
 	GlobDisableOrdering bool              `yaml:"glob_disable_ordering"`
+	Ttl                 uint64            `yaml:"ttl"`
 }
 
 type MetricMapper struct {
@@ -69,6 +70,7 @@ type MetricMapping struct {
 	HelpText        string            `yaml:"help"`
 	Action          ActionType        `yaml:"action"`
 	MatchMetricType MetricType        `yaml:"match_metric_type"`
+	Ttl             uint64            `yaml:"ttl"`
 }
 
 type metricObjective struct {
@@ -175,6 +177,10 @@ func (m *MetricMapper) InitFromYAMLString(fileContents string) error {
 
 		if currentMapping.Quantiles == nil || len(currentMapping.Quantiles) == 0 {
 			currentMapping.Quantiles = n.Defaults.Quantiles
+		}
+
+		if currentMapping.Ttl == 0 && n.Defaults.Ttl > 0 {
+			currentMapping.Ttl = n.Defaults.Ttl
 		}
 
 	}


### PR DESCRIPTION
This patch implements clearing of metrics with variable labels with per-mapping configurable timeout (ttl). Our monitoring installation is suffered from the behavior desribed in #129. There are metrics from Kubernetes pods with constantly changing values for labels. For example, metric `ingress_nginx_upstream_retries_count` with label `pod` and changing pod name as a value for this label. There is no sense to store metrics with old pod names as they are never repeated. Removing metrics with this stale values will not cause any damage to subsequent aggregations or multiple prometheus servers.

The patch is divided by 3 parts to simplify a review:
- replace Metrics with Collectors to gain ability of deletion metrics. So Elements in CounterContainer stores CounterVecs instead of Counters.
- implement labels values storage in Exporter to detect metrics staleness
- implement configurable timeout (ttl). Add key `ttl` to `default` section and to `mapping` sections.

`ttl` is a timeout in seconds for stale metrics. Exporter saves each labels values set and updates last time it receives metric with these labels values. If no metric with the same labels values received for `ttl` seconds, then statsd_exporter stops reporting metric with this labels values set.

Mark this as WIP. It would be great to hear your thoughts on this.