### PR TITLE
Bring back staticcheck on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - checkout
     - run: make promu
-    - run: make
+    - run: make all
     - run: git diff --exit-code
     - store_artifacts:
         path: statsd_exporter


### PR DESCRIPTION
this makes CircleCI use the "all" make target explicitly. In f130698
d712534 I added a new "default" target that does not include it, due to
issue #173.

PR #175 does basically this, but for TravisCI. I like the idea of not
relying on the default target.

Maybe this is fixed in CircleCI now?