### PR TITLE
Adds healthcheck for checking the status of the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,5 @@ LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com
 COPY statsd_exporter /bin/statsd_exporter
 
 EXPOSE      9102 9125 9125/udp
-HEALTHCHECK CMD curl --fail http://localhost:9102/metrics || exit 1
+HEALTHCHECK CMD wget --spider -S "http://localhost:9102/metrics" -T 60 2>&1 || exit 1
 ENTRYPOINT  [ "/bin/statsd_exporter" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,5 @@ LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com
 COPY statsd_exporter /bin/statsd_exporter
 
 EXPOSE      9102 9125 9125/udp
+HEALTHCHECK CMD curl --fail http://localhost:9102/metrics || exit 1
 ENTRYPOINT  [ "/bin/statsd_exporter" ]


### PR DESCRIPTION
What this PR does / why we need it:

Adds a healthcheck for checking the status of the metrics endpoint. 

Which issue(s) this PR fixes : This will help us recover in sitiuations like getting Internal Server Error and the container being up. 

@matthiasr Please review this. Thanks!