### PR TITLE
Add linux UDP buffer telemetry using procfs

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"runtime"
 	"strconv"
 
 	"github.com/howeyc/fsnotify"
@@ -181,6 +182,10 @@ func main() {
 
 		ul := &StatsDUDPListener{conn: uconn}
 		go ul.Listen(events)
+
+		if runtime.GOOS == "linux" {
+			go watchUDPBuffers(0, 0)
+		}
 	}
 
 	if *statsdListenTCP != "" {

--- a/telemetry_test.go
+++ b/telemetry_test.go
@@ -1,0 +1,41 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"io/ioutil"
+	"testing"
+)
+
+func TestProcfsWatching(t *testing.T) {
+	filename := "/tmp/procfstest"
+
+	d1 := []byte("  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode ref pointer drops\n42429: 00000000000000000000000000000000:1FBD 00000000000000000000000000000000:0000 07 00000000:00000034 00:00000000 00000000     0        0 1233268343 2 ffff881fc5d32ec0 10000\n")
+	err := ioutil.WriteFile(filename, d1, 0644)
+	if err != nil {
+		t.Fatalf("Should be able to write a procfs-like file: %s", err)
+	}
+
+	queued, dropped, err := parseProcfsNetFile(filename)
+	if err != nil {
+		t.Fatalf("Parsing encountered an error: %s", err)
+	}
+	if dropped != 10000 {
+		t.Fatal("Dropped should be 10000")
+	}
+
+	if queued != 52 {
+		t.Fatal("Queued should be 52", queued)
+	}
+}


### PR DESCRIPTION
We've had some problems when we cannot deploy a statsd exporter on localhost. Our exporters had misleading rate data, because the statsd exporter wasn't keeping up with events, and our linux UDP buffer was overflowing. A major part in fixing that is making it easier to track the UDP buffer overflow rate (and while I was at it, the UDP buffer current depth). This PR is for that thing.

Alternatives I explored:
I originally wanted to use https://github.com/google/cadvisor to collect this data, but was scared off of collecting UDP buffer data by a warning on one of their github issues proclaiming... `tcp/udp create an _enormous_ number of additional metric streams compared with the basic metrics`. I didn't want a large amount of metrics, I just wanted a few

I had also hoped to use the procfs library seen in the prom org, but could not find support in that library for these metrics, so I moved away from that.

I excluded non-linux OSes from this data collection because I don't have a great way to test them. 

Very open to suggestions, lemme know your thoughts.