### PR TITLE
Fixes #191: crash on empty metric name

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -334,7 +334,8 @@ func (b *Exporter) handleEvent(event Event) {
 	prometheusLabels := event.Labels()
 	if present {
 		if mapping.Name == "" {
-			log.Debugf("The mapping for match \"%v\" generates an empty metric name.", mapping.Match)
+			log.Debugf("The mapping of '%s' for match '%s' generates an empty metric name", event.MetricName(), mapping.Match)
+			errorEventStats.WithLabelValues("empty_metric_name").Inc()
 			return
 		}
 		metricName = escapeMetricName(mapping.Name)
@@ -352,7 +353,7 @@ func (b *Exporter) handleEvent(event Event) {
 		// will cause the exporter to panic. Instead we will warn and continue to the next event.
 		if event.Value() < 0.0 {
 			log.Debugf("Counter %q is: '%f' (counter must be non-negative value)", metricName, event.Value())
-			eventStats.WithLabelValues("illegal_negative_counter").Inc()
+			errorEventStats.WithLabelValues("illegal_negative_counter").Inc()
 			return
 		}
 

--- a/exporter.go
+++ b/exporter.go
@@ -280,7 +280,7 @@ type Exporter struct {
 
 func escapeMetricName(metricName string) string {
 	// If a metric starts with a digit, prepend an underscore.
-	if metricName[0] >= '0' && metricName[0] <= '9' {
+	if len(metricName) > 0 && metricName[0] >= '0' && metricName[0] <= '9' {
 		metricName = "_" + metricName
 	}
 
@@ -333,6 +333,10 @@ func (b *Exporter) handleEvent(event Event) {
 	metricName := ""
 	prometheusLabels := event.Labels()
 	if present {
+		if mapping.Name == "" {
+			log.Debugf("The mapping for match \"%v\" generates an empty metric name.", mapping.Match)
+			return
+		}
 		metricName = escapeMetricName(mapping.Name)
 		for label, value := range labels {
 			prometheusLabels[label] = value

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -60,7 +60,7 @@ func TestNegativeCounter(t *testing.T) {
 
 	updated := getTelemetryCounterValue(errorCounter)
 	if updated-prev != 1 {
-		t.Fatal("Empty metric name error event not counted")
+		t.Fatal("Illegal negative counter error not counted")
 	}
 }
 

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -199,7 +199,7 @@ func TestEscapeMetricName(t *testing.T) {
 		"with😱emoji":              "with_emoji",
 		"with.*.multiple":         "with___multiple",
 		"test.web-server.foo.bar": "test_web_server_foo_bar",
-		"": "",
+		"":                        "",
 	}
 
 	for in, want := range scenarios {

--- a/telemetry.go
+++ b/telemetry.go
@@ -102,6 +102,13 @@ var (
 		},
 		[]string{"type"},
 	)
+	errorEventStats = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "statsd_exporter_events_error_total",
+			Help: "The total number of StatsD events discarded due to errors.",
+		},
+		[]string{"reason"},
+	)
 )
 
 func init() {
@@ -119,4 +126,5 @@ func init() {
 	prometheus.MustRegister(configLoads)
 	prometheus.MustRegister(mappingsCount)
 	prometheus.MustRegister(conflictingEventStats)
+	prometheus.MustRegister(errorEventStats)
 }


### PR DESCRIPTION
Avoids crashing when escaping empty metric names.
The metrics are ignored and a message is logged. 

@matthiasr 