### PR TITLE
Add metric for count of events by action

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -322,6 +322,7 @@ func (b *Exporter) handleEvent(event Event) {
 	}
 
 	if mapping.Action == mapper.ActionTypeDrop {
+		eventsActions.WithLabelValues("drop").Inc()
 		return
 	}
 
@@ -342,6 +343,7 @@ func (b *Exporter) handleEvent(event Event) {
 		for label, value := range labels {
 			prometheusLabels[label] = value
 		}
+		eventsActions.WithLabelValues(string(mapping.Action)).Inc()
 	} else {
 		eventsUnmapped.Inc()
 		metricName = escapeMetricName(event.MetricName())

--- a/telemetry.go
+++ b/telemetry.go
@@ -109,6 +109,13 @@ var (
 		},
 		[]string{"reason"},
 	)
+	eventsActions = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "statsd_exporter_events_actions_total",
+			Help: "The total number of StatsD events by action.",
+		},
+		[]string{"action"},
+	)
 )
 
 func init() {
@@ -127,4 +134,5 @@ func init() {
 	prometheus.MustRegister(mappingsCount)
 	prometheus.MustRegister(conflictingEventStats)
 	prometheus.MustRegister(errorEventStats)
+	prometheus.MustRegister(eventsActions)
 }


### PR DESCRIPTION
As discussed in #160 

Add `statsd_exporter_events_actions_total` which is event count by mapper action. Unmapped events are not counted.