### PR TITLE
Increase escapeMetricName performance

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -21,7 +21,6 @@ import (
 	"hash/fnv"
 	"io"
 	"net"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -44,8 +43,6 @@ const (
 )
 
 var (
-	illegalCharsRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
-
 	hash   = fnv.New64a()
 	strBuf bytes.Buffer // Used for hashing.
 	intBuf = make([]byte, 8)
@@ -284,9 +281,21 @@ func escapeMetricName(metricName string) string {
 		metricName = "_" + metricName
 	}
 
-	// Replace all illegal metric chars with underscores.
-	metricName = illegalCharsRE.ReplaceAllString(metricName, "_")
-	return metricName
+	out := make([]byte, len(metricName))
+	j := 0
+	for _, c := range metricName {
+		if (c >= 'a' && c <= 'z') ||
+			(c >= 'A' && c <= 'Z') ||
+			(c >= '0' && c <= '9') {
+			out[j] = byte(c)
+		} else {
+			out[j] = byte('_')
+		}
+		j++
+	}
+
+	return string(out[:j])
+
 }
 
 // Listen handles all events sent to the given channel sequentially. It

--- a/exporter.go
+++ b/exporter.go
@@ -288,6 +288,10 @@ func escapeMetricName(metricName string) string {
 	out := make([]byte, len(metricName))
 	j := 0
 	for _, c := range metricName {
+		// check if the rune is valid for a metric name
+		// and replace it if it is not.
+		// As only certain ASCII characters are valid in metric names,
+		// we can use a byte.
 		if (c >= 'a' && c <= 'z') ||
 			(c >= 'A' && c <= 'Z') ||
 			(c >= '0' && c <= '9') {

--- a/exporter.go
+++ b/exporter.go
@@ -275,12 +275,16 @@ type Exporter struct {
 	labelValues map[string]map[uint64]*LabelValues
 }
 
+// Replace invalid characters in the metric name with "_"
+// Valid characters are a-z, A-Z, 0-9, and _
 func escapeMetricName(metricName string) string {
 	// If a metric starts with a digit, prepend an underscore.
 	if len(metricName) > 0 && metricName[0] >= '0' && metricName[0] <= '9' {
 		metricName = "_" + metricName
 	}
 
+	// this is an character replacement method optimized for this limited
+	// use case.  It is much faster than using a regex.
 	out := make([]byte, len(metricName))
 	j := 0
 	for _, c := range metricName {

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -413,3 +413,24 @@ func getTelemetryCounterValue(counter prometheus.Counter) float64 {
 	}
 	return metric.Counter.GetValue()
 }
+
+func BenchmarkEscapeMetricName(b *testing.B) {
+	scenarios := []string{
+		"clean",
+		"0starts_with_digit",
+		"with_underscore",
+		"with.dot",
+		"with😱emoji",
+		"with.*.multiple",
+		"test.web-server.foo.bar",
+		"",
+	}
+
+	for _, s := range scenarios {
+		b.Run(s, func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				escapeMetricName(s)
+			}
+		})
+	}
+}


### PR DESCRIPTION
While investigating something else,I did some profiling and found that `escapeMetricName` took a large amount of processing time. The regex was the majority of this time.  `escapeMetricName` is called on every event processed. 

The valid set of characters for a metric name is fairly small, so we can optimize this a bit.  I replaced the regex in escapeMetricName with a loop over the runes.  I originally used a `strings.Builder` to build the output, but building the string manually provided to be much faster.

This passes tests, but I am sure I am missing something obvious. This is borderline unreadable as well and needs some comments. I did this on a sick day, so I do not trust myself on this. 

For benchmarks, see https://gist.github.com/bakins/f4d342d1cc93f4911ffd4efa9d93ecab