### PR TITLE
Add metric to track unique metric names the exporter is tracking

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -102,6 +102,7 @@ func (c *CounterContainer) Get(metricName string, labels prometheus.Labels, help
 
 	counterVec, ok := c.Elements[mapKey]
 	if !ok {
+		metricsCount.Inc()
 		counterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: metricName,
 			Help: help,
@@ -138,6 +139,7 @@ func (c *GaugeContainer) Get(metricName string, labels prometheus.Labels, help s
 
 	gaugeVec, ok := c.Elements[mapKey]
 	if !ok {
+		metricsCount.Inc()
 		gaugeVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: metricName,
 			Help: help,
@@ -176,6 +178,7 @@ func (c *SummaryContainer) Get(metricName string, labels prometheus.Labels, help
 
 	summaryVec, ok := c.Elements[mapKey]
 	if !ok {
+		metricsCount.Inc()
 		quantiles := c.mapper.Defaults.Quantiles
 		if mapping != nil && mapping.Quantiles != nil && len(mapping.Quantiles) > 0 {
 			quantiles = mapping.Quantiles
@@ -224,6 +227,7 @@ func (c *HistogramContainer) Get(metricName string, labels prometheus.Labels, he
 
 	histogramVec, ok := c.Elements[mapKey]
 	if !ok {
+		metricsCount.Inc()
 		buckets := c.mapper.Defaults.Buckets
 		if mapping != nil && mapping.Buckets != nil && len(mapping.Buckets) > 0 {
 			buckets = mapping.Buckets

--- a/exporter.go
+++ b/exporter.go
@@ -102,7 +102,7 @@ func (c *CounterContainer) Get(metricName string, labels prometheus.Labels, help
 
 	counterVec, ok := c.Elements[mapKey]
 	if !ok {
-		metricsCount.Inc()
+		metricsCount.WithLabelValues("counter").Inc()
 		counterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: metricName,
 			Help: help,
@@ -120,6 +120,7 @@ func (c *CounterContainer) Delete(metricName string, labels prometheus.Labels) {
 	mapKey := getContainerMapKey(metricName, labelNames)
 	if _, ok := c.Elements[mapKey]; ok {
 		c.Elements[mapKey].Delete(labels)
+		metricsCount.WithLabelValues("counter").Dec()
 	}
 }
 
@@ -139,7 +140,7 @@ func (c *GaugeContainer) Get(metricName string, labels prometheus.Labels, help s
 
 	gaugeVec, ok := c.Elements[mapKey]
 	if !ok {
-		metricsCount.Inc()
+		metricsCount.WithLabelValues("gauge").Inc()
 		gaugeVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: metricName,
 			Help: help,
@@ -157,6 +158,7 @@ func (c *GaugeContainer) Delete(metricName string, labels prometheus.Labels) {
 	mapKey := getContainerMapKey(metricName, labelNames)
 	if _, ok := c.Elements[mapKey]; ok {
 		c.Elements[mapKey].Delete(labels)
+		metricsCount.WithLabelValues("gauge").Dec()
 	}
 }
 
@@ -178,7 +180,7 @@ func (c *SummaryContainer) Get(metricName string, labels prometheus.Labels, help
 
 	summaryVec, ok := c.Elements[mapKey]
 	if !ok {
-		metricsCount.Inc()
+		metricsCount.WithLabelValues("summary").Inc()
 		quantiles := c.mapper.Defaults.Quantiles
 		if mapping != nil && mapping.Quantiles != nil && len(mapping.Quantiles) > 0 {
 			quantiles = mapping.Quantiles
@@ -206,6 +208,7 @@ func (c *SummaryContainer) Delete(metricName string, labels prometheus.Labels) {
 	mapKey := getContainerMapKey(metricName, labelNames)
 	if _, ok := c.Elements[mapKey]; ok {
 		c.Elements[mapKey].Delete(labels)
+		metricsCount.WithLabelValues("summary").Dec()
 	}
 }
 
@@ -227,7 +230,7 @@ func (c *HistogramContainer) Get(metricName string, labels prometheus.Labels, he
 
 	histogramVec, ok := c.Elements[mapKey]
 	if !ok {
-		metricsCount.Inc()
+		metricsCount.WithLabelValues("histogram").Inc()
 		buckets := c.mapper.Defaults.Buckets
 		if mapping != nil && mapping.Buckets != nil && len(mapping.Buckets) > 0 {
 			buckets = mapping.Buckets
@@ -251,6 +254,7 @@ func (c *HistogramContainer) Delete(metricName string, labels prometheus.Labels)
 	mapKey := getContainerMapKey(metricName, labelNames)
 	if _, ok := c.Elements[mapKey]; ok {
 		c.Elements[mapKey].Delete(labels)
+		metricsCount.WithLabelValues("histogram").Dec()
 	}
 }
 

--- a/telemetry.go
+++ b/telemetry.go
@@ -116,6 +116,12 @@ var (
 		},
 		[]string{"action"},
 	)
+	metricsCount = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "statsd_exporter_metrics_total",
+			Help: "The total number of metrics.",
+		},
+	)
 )
 
 func init() {
@@ -135,4 +141,5 @@ func init() {
 	prometheus.MustRegister(conflictingEventStats)
 	prometheus.MustRegister(errorEventStats)
 	prometheus.MustRegister(eventsActions)
+	prometheus.MustRegister(metricsCount)
 }

--- a/telemetry.go
+++ b/telemetry.go
@@ -116,11 +116,12 @@ var (
 		},
 		[]string{"action"},
 	)
-	metricsCount = prometheus.NewCounter(
-		prometheus.CounterOpts{
+	metricsCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
 			Name: "statsd_exporter_metrics_total",
 			Help: "The total number of metrics.",
 		},
+		[]string{"type"},
 	)
 )
 


### PR DESCRIPTION
Currently, we track the number of mappings, but not the unique metricNames.  This adds a simple counter to track the count of metricName+labelNames.  If this number increases significantly, then the application sending metrics may be misbehaving.  This does not count unique label values.

I didn't see a way to get this in the current metrics, so please let me know if there is an existing way to get this information.