### PR TITLE
Don't run docker container as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com
 
 COPY statsd_exporter /bin/statsd_exporter
 
+USER        nobody
 EXPOSE      9102 9125 9125/udp
 HEALTHCHECK CMD wget --spider -S "http://localhost:9102/metrics" -T 60 2>&1 || exit 1
 ENTRYPOINT  [ "/bin/statsd_exporter" ]


### PR DESCRIPTION
Run statsd_exporter as `nobody`.

Closes: https://github.com/prometheus/statsd_exporter/issues/201

Signed-off-by: Ben Kochie <superq@gmail.com>