### PR TITLE
Tag parsing optimizations

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -600,14 +600,25 @@ func parseDogStatsDTagsToLabels(component string) map[string]string {
 			t = t[1:]
 		}
 
-		kv := strings.SplitN(t, ":", 2)
-		if len(kv) < 2 || len(kv[1]) == 0 {
+		// find the first comma and split the tag into key and value.
+		var k, v string
+		for i, c := range t {
+			if c == ':' {
+				k = t[0:i]
+				v = t[(i + 1):]
+				break
+			}
+		}
+
+		// If either of them is empty, then either the k or v is empty, or we
+		// didn't find a colon, either way, throw an error and skip ahead.
+		if len(k) == 0 || len(v) == 0 {
 			tagErrors.Inc()
 			log.Debugf("Malformed or empty DogStatsD tag %s in component %s", t, component)
 			continue
 		}
 
-		labels[escapeMetricName(kv[0])] = kv[1]
+		labels[escapeMetricName(k)] = v
 	}
 	return labels
 }

--- a/exporter.go
+++ b/exporter.go
@@ -589,9 +589,18 @@ func parseDogStatsDTagsToLabels(component string) map[string]string {
 	tagsReceived.Inc()
 	tags := strings.Split(component, ",")
 	for _, t := range tags {
-		t = strings.TrimPrefix(t, "#")
-		kv := strings.SplitN(t, ":", 2)
+		// Bail early if the tag is empty
+		if len(t) == 0 {
+			tagErrors.Inc()
+			log.Debugf("Empty tag found in '%s'", component)
+			continue
+		}
+		// Skip hash if found.
+		if t[0] == '#' {
+			t = t[1:]
+		}
 
+		kv := strings.SplitN(t, ":", 2)
 		if len(kv) < 2 || len(kv[1]) == 0 {
 			tagErrors.Inc()
 			log.Debugf("Malformed or empty DogStatsD tag %s in component %s", t, component)

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -527,3 +527,21 @@ func BenchmarkEscapeMetricName(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkParseDogStatsDTagsToLabels(b *testing.B) {
+	scenarios := map[string]string{
+		"1 tag w/hash":         "#test:tag",
+		"1 tag w/o hash":       "test:tag",
+		"2 tags, mixed hashes": "tag1:test,#tag2:test",
+		"3 long tags":          "tag1:reallylongtagthisisreallylong,tag2:anotherreallylongtag,tag3:thisisyetanotherextraordinarilylongtag",
+		"a-z tags":             "a:0,b:1,c:2,d:3,e:4,f:5,g:6,h:7,i:8,j:9,k:0,l:1,m:2,n:3,o:4,p:5,q:6,r:7,s:8,t:9,u:0,v:1,w:2,x:3,y:4,z:5",
+	}
+
+	for name, tags := range scenarios {
+		b.Run(name, func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				parseDogStatsDTagsToLabels(tags)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Profiling shows that for our environment, parsing tags is the single biggest steady state contributor to CPU usage.  This PR replaces some calls to strings library functions to simpler implementations with the intention of reducing CPU overhead and some memory allocations.  

Here is an example of the before scenario:
```
$ time go test -bench=BenchmarkParseDogStatsDTagsToLabels -test.benchmem -benchtime 60s
goos: darwin
goarch: amd64
pkg: github.com/prometheus/statsd_exporter
BenchmarkParseDogStatsDTagsToLabels/1_tag_w/hash-8              300000000              319 ns/op             392 B/op          6 allocs/op
BenchmarkParseDogStatsDTagsToLabels/1_tag_w/o_hash-8            300000000              318 ns/op             392 B/op          6 allocs/op
BenchmarkParseDogStatsDTagsToLabels/2_tags,_mixed_hashes-8      200000000              490 ns/op             448 B/op          9 allocs/op
BenchmarkParseDogStatsDTagsToLabels/3_long_tags-8               100000000              673 ns/op             504 B/op         12 allocs/op
BenchmarkParseDogStatsDTagsToLabels/a-z_tags-8                  20000000              5408 ns/op            3622 B/op         57 allocs/op
PASS
ok      github.com/prometheus/statsd_exporter   584.443s
```

And here is what it looks like afterwards:

```
$ time go test -bench=BenchmarkParseDogStatsDTagsToLabels -test.benchmem -benchtime 60s
goos: darwin
goarch: amd64
pkg: github.com/prometheus/statsd_exporter
BenchmarkParseDogStatsDTagsToLabels/1_tag_w/hash-8              500000000              209 ns/op             344 B/op          4 allocs/op
BenchmarkParseDogStatsDTagsToLabels/1_tag_w/o_hash-8            500000000              201 ns/op             344 B/op          4 allocs/op
BenchmarkParseDogStatsDTagsToLabels/2_tags,_mixed_hashes-8      300000000              282 ns/op             352 B/op          6 allocs/op
BenchmarkParseDogStatsDTagsToLabels/3_long_tags-8               200000000              393 ns/op             360 B/op          8 allocs/op
BenchmarkParseDogStatsDTagsToLabels/a-z_tags-8                  30000000              2871 ns/op            2374 B/op         30 allocs/op
PASS
ok      github.com/prometheus/statsd_exporter   566.397s
```