### PR TITLE
Add support for Datadog distribution type

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ mappings:
     job: "${1}_server"
 ```
 
+Note that timers will be accepted with the `ms`, `h`, and `d` statsd types.  The first two are timers and histograms and the `d` type is for DataDog's "distribution" type.  The distribution type is treated identically to timers and histograms.
+
 ### Regular expression matching
 
 Another capability when using YAML configuration is the ability to define matches

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -68,6 +68,26 @@ func TestHandlePacket(t *testing.T) {
 				},
 			},
 		}, {
+			name: "simple histogram",
+			in:   "foo:200|h",
+			out: Events{
+				&TimerEvent{
+					metricName: "foo",
+					value:      200,
+					labels:     map[string]string{},
+				},
+			},
+		}, {
+			name: "simple distribution",
+			in:   "foo:200|d",
+			out: Events{
+				&TimerEvent{
+					metricName: "foo",
+					value:      200,
+					labels:     map[string]string{},
+				},
+			},
+		}, {
 			name: "datadog tag extension",
 			in:   "foo:100|c|#tag1:bar,tag2:baz",
 			out: Events{

--- a/exporter.go
+++ b/exporter.go
@@ -571,7 +571,7 @@ func buildEvent(statType, metric string, value float64, relative bool, labels ma
 			relative:   relative,
 			labels:     labels,
 		}, nil
-	case "ms", "h":
+	case "ms", "h", "d":
 		return &TimerEvent{
 			metricName: metric,
 			value:      float64(value),


### PR DESCRIPTION
This adds the ability to accept Datadog's distribution type and treat it like a histogram/summary.