### PR TITLE
Check for histogram conflict on main name

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -262,6 +262,9 @@ func (c *HistogramContainer) Get(metricName string, labels prometheus.Labels, mc
 
 	histogramVec, ok := c.Elements[mapKey]
 	if !ok {
+		if mc.metricConflicts(metricName, HistogramMetricType) {
+			return nil, fmt.Errorf("metric with name %s is already registered", metricName)
+		}
 		if mc.metricConflicts(metricName+"_sum", HistogramMetricType) {
 			return nil, fmt.Errorf("metric with name %s is already registered", metricName)
 		}

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -236,6 +236,20 @@ func TestConflictingMetrics(t *testing.T) {
 			},
 		},
 		{
+			name:     "counter vs histogram",
+			expected: []float64{1},
+			in: Events{
+				&CounterEvent{
+					metricName: "histogram_test1",
+					value:      1,
+				},
+				&TimerEvent{
+					metricName: "histogram.test1",
+					value:      2,
+				},
+			},
+		},
+		{
 			name:     "counter vs histogram sum",
 			expected: []float64{1},
 			in: Events{


### PR DESCRIPTION
While it doesn't report it as a metric, when collecting, the registry considers the base metric name to belong to the histogram that's registered.  This means that we need to prevent other metrics from
registering anything under this name, in addition to checking for the `_bucket`, `_sum` and `_count` suffixes.

This was missed in #213 