### PR TITLE
Optimize label sorting

### DIFF
--- a/exporter_test.go
+++ b/exporter_test.go
@@ -724,9 +724,12 @@ func getFloat64(metrics []*dto.MetricFamily, name string, labels prometheus.Labe
 	}
 
 	var metric *dto.Metric
-	labelsHash := hashNameAndLabels(name, labels)
+	sortedLabelNames := getSortedLabelNames(labels)
+	labelsHash := hashNameAndLabels(name, sortedLabelNames, labels)
 	for _, m := range metricFamily.Metric {
-		h := hashNameAndLabels(name, labelPairsAsLabels(m.GetLabel()))
+		l := labelPairsAsLabels(m.GetLabel())
+		sln := getSortedLabelNames(l)
+		h := hashNameAndLabels(name, sln, l)
 		if h == labelsHash {
 			metric = m
 			break
@@ -858,9 +861,10 @@ func BenchmarkHashNameAndLabels(b *testing.B) {
 	}
 
 	for _, s := range scenarios {
+		sortedLabelNames := getSortedLabelNames(s.labels)
 		b.Run(s.name, func(b *testing.B) {
 			for n := 0; n < b.N; n++ {
-				hashNameAndLabels(s.metric, s.labels)
+				hashNameAndLabels(s.metric, sortedLabelNames, s.labels)
 			}
 		})
 	}

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -822,3 +822,46 @@ func BenchmarkParseDogStatsDTagsToLabels(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkHashNameAndLabels(b *testing.B) {
+	scenarios := []struct {
+		name   string
+		metric string
+		labels map[string]string
+	}{
+		{
+			name:   "no labels",
+			metric: "counter",
+			labels: map[string]string{},
+		}, {
+			name:   "one label",
+			metric: "counter",
+			labels: map[string]string{
+				"label": "value",
+			},
+		}, {
+			name:   "many labels",
+			metric: "counter",
+			labels: map[string]string{
+				"label0": "value",
+				"label1": "value",
+				"label2": "value",
+				"label3": "value",
+				"label4": "value",
+				"label5": "value",
+				"label6": "value",
+				"label7": "value",
+				"label8": "value",
+				"label9": "value",
+			},
+		},
+	}
+
+	for _, s := range scenarios {
+		b.Run(s.name, func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				hashNameAndLabels(s.metric, s.labels)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Previously we were sorting labels in every container to build a map key, but also when generating the hash key by calling the `LabelsToSignature` method.  This moves the sorting to be done early in the event processing then passes the sorted label array around.

Before:
```
$ /usr/local/bin/go test -benchmem -run=^$ github.com/prometheus/statsd_exporter -bench '^(BenchmarkHashNameAndLabels)$' -benchtime 5s
goos: darwin
goarch: amd64
pkg: github.com/prometheus/statsd_exporter
BenchmarkHashNameAndLabels/no_labels-8          300000000               26.7 ns/op             0 B/op          0 allocs/op
BenchmarkHashNameAndLabels/one_label-8          50000000               163 ns/op              48 B/op          2 allocs/op
BenchmarkHashNameAndLabels/many_labels-8        10000000               889 ns/op             192 B/op          2 allocs/op
PASS
ok      github.com/prometheus/statsd_exporter   28.928s
```

After:
```
$ /usr/local/bin/go test -benchmem -run=^$ github.com/prometheus/statsd_exporter -bench '^(BenchmarkHashNameAndLabels)$' -benchtime 5s
goos: darwin
goarch: amd64
pkg: github.com/prometheus/statsd_exporter
BenchmarkHashNameAndLabels/no_labels-8          300000000               21.5 ns/op             0 B/op          0 allocs/op
BenchmarkHashNameAndLabels/one_label-8          100000000               59.8 ns/op             0 B/op          0 allocs/op
BenchmarkHashNameAndLabels/many_labels-8        20000000               507 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/prometheus/statsd_exporter   25.530s
```