### PR TITLE
Fix parsing labels from metric names.

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -458,7 +458,6 @@ func (b *Exporter) handleEvent(event Event) {
 
 	metricName := ""
 	prometheusLabels := event.Labels()
-	sortedLabelNames := getSortedLabelNames(prometheusLabels)
 	if present {
 		if mapping.Name == "" {
 			log.Debugf("The mapping of '%s' for match '%s' generates an empty metric name", event.MetricName(), mapping.Match)
@@ -474,6 +473,7 @@ func (b *Exporter) handleEvent(event Event) {
 		eventsUnmapped.Inc()
 		metricName = escapeMetricName(event.MetricName())
 	}
+	sortedLabelNames := getSortedLabelNames(prometheusLabels)
 
 	switch ev := event.(type) {
 	case *CounterEvent:


### PR DESCRIPTION
The list of label names used in creating a metric is a list of strings
derived from string:string map containing the actual Prometheus labels.
This map was being acquired from the Event and then any labels parsed out
of the metric name are added. Problematically the list of label names was
acquired before any parsed-out labels were added and thus these would be
missing leading to cardinality errors upon updating the metric.

Also adds a test for this behaviour.