### PR TITLE
Fix inconsistent label cardinality error

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -458,7 +458,6 @@ func (b *Exporter) handleEvent(event Event) {
 
 	metricName := ""
 	prometheusLabels := event.Labels()
-	sortedLabelNames := getSortedLabelNames(prometheusLabels)
 	if present {
 		if mapping.Name == "" {
 			log.Debugf("The mapping of '%s' for match '%s' generates an empty metric name", event.MetricName(), mapping.Match)
@@ -475,6 +474,7 @@ func (b *Exporter) handleEvent(event Event) {
 		metricName = escapeMetricName(event.MetricName())
 	}
 
+	sortedLabelNames := getSortedLabelNames(prometheusLabels)
 	switch ev := event.(type) {
 	case *CounterEvent:
 		// We don't accept negative values for counters. Incrementing the counter with a negative number


### PR DESCRIPTION
Hi.

I've faced issue with latest statsd version: `Failed to update metric "asr_duration". Error: inconsistent label cardinality: expected 0 label values but got 4 in prometheus.Labels`

It happened after this commit https://github.com/prometheus/statsd_exporter/commit/d143398343bc68ba149e51bdd84acf6e679118fd 

Basically we sort prometheus labels (https://github.com/prometheus/statsd_exporter/blob/master/exporter.go#L461) before fill structure (https://github.com/prometheus/statsd_exporter/blob/master/exporter.go#L470)

Fixes issue for me, also rollback to v0.9.0 fixes it.