### PR TITLE
Make mapper cache respect metric type

### DIFF
--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -237,7 +237,7 @@ func (m *MetricMapper) InitCache(cacheSize int) {
 func (m *MetricMapper) GetMapping(statsdMetric string, statsdMetricType MetricType) (*MetricMapping, prometheus.Labels, bool) {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
-	result, cached := m.cache.Get(statsdMetric)
+	result, cached := m.cache.Get(statsdMetric, statsdMetricType)
 	if cached {
 		return result.Mapping, result.Labels, result.Matched
 	}
@@ -253,12 +253,12 @@ func (m *MetricMapper) GetMapping(statsdMetric string, statsdMetricType MetricTy
 				labels[result.labelKeys[index]] = formatter.Format(captures)
 			}
 
-			m.cache.AddMatch(statsdMetric, result, labels)
+			m.cache.AddMatch(statsdMetric, statsdMetricType, result, labels)
 
 			return result, labels, true
 		} else if !m.doRegex {
 			// if there's no regex match type, return immediately
-			m.cache.AddMiss(statsdMetric)
+			m.cache.AddMiss(statsdMetric, statsdMetricType)
 			return nil, nil, false
 		}
 	}
@@ -291,11 +291,11 @@ func (m *MetricMapper) GetMapping(statsdMetric string, statsdMetricType MetricTy
 			labels[label] = string(value)
 		}
 
-		m.cache.AddMatch(statsdMetric, &mapping, labels)
+		m.cache.AddMatch(statsdMetric, statsdMetricType, &mapping, labels)
 
 		return &mapping, labels, true
 	}
 
-	m.cache.AddMiss(statsdMetric)
+	m.cache.AddMiss(statsdMetric, statsdMetricType)
 	return nil, nil, false
 }


### PR DESCRIPTION
- Statsd allows users to provide a metric with the same name but
  differing types (counter, gauge, timer)
- The exporter allows this by letting users specify a
  "match_metric_type" in the mapping config
- However the mapper cache does not look at the metric type so it would
  return a MetricMapperCacheResult for the type of the first metric with
that name that the exporter saw
- Add MetricType to the signature for the cache and format the metric
  name with the type to provide unique keys for a metric with the same
name but differing type

Fixes #228 