### PR TITLE
add missing eventHandler to StatsDTCPListener

### DIFF
--- a/main.go
+++ b/main.go
@@ -202,7 +202,7 @@ func main() {
 		}
 		defer tconn.Close()
 
-		tl := &StatsDTCPListener{conn: tconn}
+		tl := &StatsDTCPListener{conn: tconn, eventHandler: eventQueue}
 		go tl.Listen()
 	}
 


### PR DESCRIPTION
When sending data with TCP exporter was panicking.

```
echo "foo_bar:1|c" | nc localhost 9125
```

```
INFO[0000] Starting StatsD -> Prometheus Exporter (version=, branch=, revision=)  source="main.go:168"
INFO[0000] Build context (go=go1.12.4, user=, date=)     source="main.go:169"
INFO[0000] Accepting StatsD Traffic: UDP :9125, TCP :9125, Unixgram   source="main.go:170"
INFO[0000] Accepting Prometheus Requests on :9102        source="main.go:171"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1491d98]

goroutine 14 [running]:
main.(*StatsDTCPListener).handleConn(0xc000146ac0, 0xc000010048)
	/Users/selman/src/statsd_exporter/exporter.go:514 +0x208
created by main.(*StatsDTCPListener).Listen
	/Users/selman/src/statsd_exporter/exporter.go:489 +0x4a
```


In tests `eventHandler` was set for both listeners;
https://github.com/prometheus/statsd_exporter/blob/a276bacac90f7cb64b93f3f4230687dec9bbe35d/bridge_test.go#L296
but not in `main.go`;
https://github.com/prometheus/statsd_exporter/blob/a276bacac90f7cb64b93f3f4230687dec9bbe35d/main.go#L205