### PR TITLE
Fix TTL bug

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -169,6 +169,8 @@ func (r *registry) get(metricName string, hash labelHash, metricType metricType)
 
 	rm, ok := metric.metrics[hash.values]
 	if ok {
+		now := clock.Now()
+		rm.lastRegisteredAt = now
 		return metric.vectors[hash.names].holder, rm.metric
 	}
 


### PR DESCRIPTION
Fixes a bug where setting the TTL parameter would periodically remove time series.
The reason for this was that the 'lastRegisteredAt' element was only set at creation of the time series, and not updated every time a new event was received for that time series.
__Maintainer:__ (@matthiasr)