### PR TITLE
Add note about DogStatsD `use_ms` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ mappings:
 
 Note that timers will be accepted with the `ms`, `h`, and `d` statsd types.  The first two are timers and histograms and the `d` type is for DataDog's "distribution" type.  The distribution type is treated identically to timers and histograms.
 
-The DogStatsD client by default emits timer metrics in seconds, set [use_ms](https://github.com/DataDog/datadogpy/blob/master/datadog/dogstatsd/base.py#L63) to `True` to fix this.
+The DogStatsD client by default emits timer metrics in seconds, set [use_ms](https://datadogpy.readthedocs.io/en/latest/index.html?highlight=use_ms) to `True` to fix this.
 
 ### Regular expression matching
 

--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ mappings:
 
 Note that timers will be accepted with the `ms`, `h`, and `d` statsd types.  The first two are timers and histograms and the `d` type is for DataDog's "distribution" type.  The distribution type is treated identically to timers and histograms.
 
+The DogStatsD client by default emits timer metrics in seconds, set [use_ms](https://github.com/DataDog/datadogpy/blob/master/datadog/dogstatsd/base.py#L63) to `True` to fix this.
+
 ### Regular expression matching
 
 Another capability when using YAML configuration is the ability to define matches


### PR DESCRIPTION
DogStatsD by default emits timer metric in seconds, while the exporter assumes milliseconds; which is the default for statsd. The `use_ms` option fixes this, and will be useful for dogstatsd users to know.