### PR TITLE
README - Add a note regarding unit conversions for timers

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,10 @@ mappings:
 
 Note that timers will be accepted with the `ms`, `h`, and `d` statsd types.  The first two are timers and histograms and the `d` type is for DataDog's "distribution" type.  The distribution type is treated identically to timers and histograms.
 
+It should be noted that whereas timers in statsd expects the unit of timing data to be in milliseconds, 
+prometheus expects the unit to be seconds. Hence, the exporter converts all timers to seconds 
+before exporting them.
+
 ### DogStatsD Client Behavior
 
 #### `timed()` decorator


### PR DESCRIPTION
While rolling out `statsd exporter`, this is one of the things that confused me. What's the final unit of the exported metric when I am querying prometheus? I took a look at the code to clarify, so thought adding this in the documentation is a good idea. 

Please take a look.