### PR TITLE
Add librato tag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,37 @@ We recommend this only as an intermediate solution and recommend switching to
 [native Prometheus instrumentation](http://prometheus.io/docs/instrumenting/clientlibs/)
 in the long term.
 
-### DogStatsD extensions
+### Tagging Extensions
 
-The exporter will convert DogStatsD-style tags to prometheus labels. See
-[Tags](https://docs.datadoghq.com/developers/dogstatsd/data_types/#tagging) in the DogStatsD
-documentation for the concept description and
-[Datagram Format](https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/)
-for specifics. It boils down to appending
-`|#tag:value,another_tag:another_value` to the normal StatsD format.  Tags
-without values (`#some_tag`) are not supported.
+The exporter supports both Librato-style tags and DogStatsD-style tags,
+which will be converted into Prometheus labels.
+
+For Librato-style tags, they must be appended to the metric name, as so:
+
+```
+metric.name#tagName=val,tag2Name=val2:0|c
+```
+
+See the [statsd-librato-backend README](https://github.com/librato/statsd-librato-backend#tags)
+for a more complete description.
+
+For DogStatsD-style tags, they're appended as another section at the end of the
+metric, as so:
+
+```
+metric.name:0|c|#tagName=val,tag2Name=val2
+```
+
+See [Tags](https://docs.datadoghq.com/developers/dogstatsd/data_types/#tagging)
+in the DogStatsD documentation for the concept description and
+[Datagram Format](https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/).
+
+Although you can use both tag types simultaneously, this is not recommended.
+DogStatsD `name=value` pairs will take priority over Librato tags with the same
+name.
+
+For both Librato and DogStatsD tags, tags without values (`#some_tag`) are not
+supported.
 
 ## Building and Running
 
@@ -235,8 +257,8 @@ mappings:
 
 Note that timers will be accepted with the `ms`, `h`, and `d` statsd types.  The first two are timers and histograms and the `d` type is for DataDog's "distribution" type.  The distribution type is treated identically to timers and histograms.
 
-It should be noted that whereas timers in statsd expects the unit of timing data to be in milliseconds, 
-prometheus expects the unit to be seconds. Hence, the exporter converts all timers to seconds 
+It should be noted that whereas timers in statsd expects the unit of timing data to be in milliseconds,
+prometheus expects the unit to be seconds. Hence, the exporter converts all timers to seconds
 before exporting them.
 
 ### DogStatsD Client Behavior

--- a/README.md
+++ b/README.md
@@ -65,16 +65,12 @@ metric.name:0|c|#tagName=val,tag2Name=val2
 See [Tags](https://docs.datadoghq.com/developers/dogstatsd/data_types/#tagging)
 in the DogStatsD documentation for the concept description and
 [Datagram Format](https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/).
-Note that this tagging style is incompatible with the original `statsd`
-implementation, you will be unable to use it as a repeater in front of the
-statsd-to-prometheus exporter.
+If you encounter problems, note that this tagging style is incompatible with
+the original `statsd` implementation.
 
-Although you can use both name-appended tags (Librato or InfluxDB) and
-metric-appended tags simultaneously, this is not recommended. If you do, be
-aware that DogStatsD `name=value` pairs will take priority over Librato tags
-with the same name.
-
-Tags without values (`#some_tag`) are not supported and will be dropped.
+Be aware: If you mix tag styles (e.g., Librato/InfluxDB with DogStatsD), the
+exporter will consider this an error and the sample will be discarded. Also,
+tags without values (`#some_tag`) are not supported and will be ignored.
 
 ## Building and Running
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ in the long term.
 
 ### Tagging Extensions
 
-The exporter supports both Librato-style tags and DogStatsD-style tags,
+The exporter supports Librato, InfluxDB, and DogStatsD-style tags,
 which will be converted into Prometheus labels.
 
-For Librato-style tags, they must be appended to the metric name, as so:
+For Librato-style tags, they must be appended to the metric name with a
+delimiting `#`, as so:
 
 ```
 metric.name#tagName=val,tag2Name=val2:0|c
@@ -43,8 +44,19 @@ metric.name#tagName=val,tag2Name=val2:0|c
 See the [statsd-librato-backend README](https://github.com/librato/statsd-librato-backend#tags)
 for a more complete description.
 
-For DogStatsD-style tags, they're appended as another section at the end of the
-metric, as so:
+For InfluxDB-style tags, they must be appended to the metric name with a
+delimiting comma, as so:
+
+```
+metric.name,tagName=val,tag2Name=val2:0|c
+```
+
+See [this InfluxDB blog post](https://www.influxdata.com/blog/getting-started-with-sending-statsd-metrics-to-telegraf-influxdb/#introducing-influx-statsd)
+for a larger overview.
+
+
+For DogStatsD-style tags, they're appended as a `|#` delimited section at the
+end of the metric, as so:
 
 ```
 metric.name:0|c|#tagName=val,tag2Name=val2
@@ -53,13 +65,16 @@ metric.name:0|c|#tagName=val,tag2Name=val2
 See [Tags](https://docs.datadoghq.com/developers/dogstatsd/data_types/#tagging)
 in the DogStatsD documentation for the concept description and
 [Datagram Format](https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/).
+Note that this tagging style is incompatible with the original `statsd`
+implementation, you will be unable to use it as a repeater in front of the
+statsd-to-prometheus exporter.
 
-Although you can use both tag types simultaneously, this is not recommended.
-DogStatsD `name=value` pairs will take priority over Librato tags with the same
-name.
+Although you can use both name-appended tags (Librato or InfluxDB) and
+metric-appended tags simultaneously, this is not recommended. If you do, be
+aware that DogStatsD `name=value` pairs will take priority over Librato tags
+with the same name.
 
-For both Librato and DogStatsD tags, tags without values (`#some_tag`) are not
-supported.
+Tags without values (`#some_tag`) are not supported and will be dropped.
 
 ## Building and Running
 

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -149,7 +149,7 @@ func TestHandlePacket(t *testing.T) {
 			},
 		}, {
 			name: "influxdb tag extension",
-			in:   "foo#tag1=bar,tag2=baz:100|c",
+			in:   "foo,tag1=bar,tag2=baz:100|c",
 			out: Events{
 				&CounterEvent{
 					metricName: "foo",
@@ -159,7 +159,7 @@ func TestHandlePacket(t *testing.T) {
 			},
 		}, {
 			name: "influxdb tag extension with tag keys unsupported by prometheus",
-			in:   "foo#09digits=0,tag.with.dots=1:100|c",
+			in:   "foo,09digits=0,tag.with.dots=1:100|c",
 			out: Events{
 				&CounterEvent{
 					metricName: "foo",

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -128,6 +128,26 @@ func TestHandlePacket(t *testing.T) {
 				},
 			},
 		}, {
+			name: "librato tag extension",
+			in:   "foo#tag1=bar,tag2=baz:100|c",
+			out: Events{
+				&CounterEvent{
+					metricName: "foo",
+					value:      100,
+					labels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		}, {
+			name: "librato tag extension with tag keys unsupported by prometheus",
+			in:   "foo#09digits=0,tag.with.dots=1:100|c",
+			out: Events{
+				&CounterEvent{
+					metricName: "foo",
+					value:      100,
+					labels:     map[string]string{"_09digits": "0", "tag_with_dots": "1"},
+				},
+			},
+		}, {
 			name: "datadog tag extension",
 			in:   "foo:100|c|#tag1:bar,tag2:baz",
 			out: Events{
@@ -195,6 +215,16 @@ func TestHandlePacket(t *testing.T) {
 					metricName: "foo",
 					value:      1000,
 					labels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		}, {
+			name: "librato and datadog tag extension with sampling",
+			in:   "foo#tag1=foo,tag3=bing:100|c|@0.1|#tag1:bar,#tag2:baz",
+			out: Events{
+				&CounterEvent{
+					metricName: "foo",
+					value:      1000,
+					labels:     map[string]string{"tag1": "bar", "tag3": "bing", "tag2": "baz"},
 				},
 			},
 		}, {

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -238,15 +238,17 @@ func TestHandlePacket(t *testing.T) {
 				},
 			},
 		}, {
-			name: "librato and datadog tag extension with sampling",
+			name: "librato/dogstatsd mixed tag styles without sampling",
+			in:   "foo#tag1=foo,tag3=bing:100|c|#tag1:bar,#tag2:baz",
+			out:  Events{},
+		}, {
+			name: "influxdb/dogstatsd mixed tag styles without sampling",
+			in:   "foo,tag1=foo,tag3=bing:100|c|#tag1:bar,#tag2:baz",
+			out:  Events{},
+		}, {
+			name: "mixed tag styles with sampling",
 			in:   "foo#tag1=foo,tag3=bing:100|c|@0.1|#tag1:bar,#tag2:baz",
-			out: Events{
-				&CounterEvent{
-					metricName: "foo",
-					value:      1000,
-					labels:     map[string]string{"tag1": "bar", "tag3": "bing", "tag2": "baz"},
-				},
-			},
+			out:  Events{},
 		}, {
 			name: "histogram with sampling",
 			in:   "foo:0.01|h|@0.2|#tag1:bar,#tag2:baz",

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -148,6 +148,26 @@ func TestHandlePacket(t *testing.T) {
 				},
 			},
 		}, {
+			name: "influxdb tag extension",
+			in:   "foo#tag1=bar,tag2=baz:100|c",
+			out: Events{
+				&CounterEvent{
+					metricName: "foo",
+					value:      100,
+					labels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		}, {
+			name: "influxdb tag extension with tag keys unsupported by prometheus",
+			in:   "foo#09digits=0,tag.with.dots=1:100|c",
+			out: Events{
+				&CounterEvent{
+					metricName: "foo",
+					value:      100,
+					labels:     map[string]string{"_09digits": "0", "tag_with_dots": "1"},
+				},
+			},
+		}, {
 			name: "datadog tag extension",
 			in:   "foo:100|c|#tag1:bar,tag2:baz",
 			out: Events{

--- a/exporter.go
+++ b/exporter.go
@@ -279,7 +279,7 @@ func extractNameTag(component, tag string, labels map[string]string) {
 	// Empty tag is an error
 	if len(tag) == 0 {
 		tagErrors.Inc()
-		log.Debugf("Empty Librato tag in component %s", component)
+		log.Debugf("Empty name tag in component %s", component)
 		return
 	}
 
@@ -291,7 +291,7 @@ func extractNameTag(component, tag string, labels map[string]string) {
 			if len(k) == 0 || len(v) == 0 {
 				// Empty key or value, so it's an error
 				tagErrors.Inc()
-				log.Debugf("Malformed Librato tag %s=%s in component %s", k, v, component)
+				log.Debugf("Malformed name tag %s=%s in component %s", k, v, component)
 			} else {
 				labels[escapeMetricName(k)] = v
 			}
@@ -301,7 +301,7 @@ func extractNameTag(component, tag string, labels map[string]string) {
 
 	// Could not find an equals sign, so it's an error
 	tagErrors.Inc()
-	log.Debugf("Malformed Librato tag %s in component %s", tag, component)
+	log.Debugf("Malformed name tag %s in component %s", tag, component)
 }
 
 func parseNameTag(component string, labels map[string]string) {

--- a/exporter.go
+++ b/exporter.go
@@ -399,9 +399,19 @@ func lineToEvents(line string) Events {
 
 	labels := map[string]string{}
 	metric := parseNameAndLabels(elements[0], labels)
+
 	var samples []string
 	if strings.Contains(elements[1], "|#") {
-		// using datadog extensions, disable multi-metrics
+		// using datadog extensions
+
+		// don't allow mixed tagging styles
+		if len(labels) > 0 {
+			sampleErrors.WithLabelValues("malformed_line").Inc()
+			log.Debugln("Bad line (multiple tagging styles) from StatsD:", line)
+			return events
+		}
+
+		// disable multi-metrics
 		samples = elements[1:]
 	} else {
 		samples = strings.Split(elements[1], ":")

--- a/exporter.go
+++ b/exporter.go
@@ -381,7 +381,7 @@ func lineToEvents(line string) Events {
 
 		// don't allow mixed tagging styles
 		if len(labels) > 0 {
-			sampleErrors.WithLabelValues("malformed_line").Inc()
+			sampleErrors.WithLabelValues("mixed_tagging_styles").Inc()
 			log.Debugln("Bad line (multiple tagging styles) from StatsD:", line)
 			return events
 		}

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -953,7 +953,8 @@ func BenchmarkParseDogStatsDTagsToLabels(b *testing.B) {
 	for name, tags := range scenarios {
 		b.Run(name, func(b *testing.B) {
 			for n := 0; n < b.N; n++ {
-				parseDogStatsDTagsToLabels(tags)
+				labels := map[string]string{}
+				parseDogStatsDTagsToLabels(tags, labels)
 			}
 		})
 	}

--- a/exporter_test.go
+++ b/exporter_test.go
@@ -941,7 +941,7 @@ func BenchmarkEscapeMetricName(b *testing.B) {
 	}
 }
 
-func BenchmarkParseDogStatsDTagsToLabels(b *testing.B) {
+func BenchmarkParseDogStatsDTags(b *testing.B) {
 	scenarios := map[string]string{
 		"1 tag w/hash":         "#test:tag",
 		"1 tag w/o hash":       "test:tag",
@@ -954,7 +954,7 @@ func BenchmarkParseDogStatsDTagsToLabels(b *testing.B) {
 		b.Run(name, func(b *testing.B) {
 			for n := 0; n < b.N; n++ {
 				labels := map[string]string{}
-				parseDogStatsDTagsToLabels(tags, labels)
+				parseDogStatsDTags(tags, labels)
 			}
 		})
 	}


### PR DESCRIPTION
## What

Add support for Librato-style tags. These appear in the metric name rather than as a separate field, ala:

```
metric.name#tag=val,tag2=val2:0|c
```

## Why

Maybe this is just scratching my itch, but I'm facing the impossibility of attempting to incrementally move from Librato (and librato tags) to an internal Prometheus server. The only way forward for me is to either heavily hack the original Statsd server and the Librato backend plugin to support DogStatsD tags, or to add a bit of support to this exporter, which is what I've opted to do.

## Discussion

This is a fairly straightforward implementation, and is almost entirely backwards compatible, so I didn't bother to invoke the mailing list. The only place this might break is if someone is already using metrics with hash signs in them -- but this should probably not be occurring in most cases. If desired, I can add a configuration flag for this to prevent conflicts.