### PR TITLE
Fix format for dogstatsd tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ For DogStatsD-style tags, they're appended as a `|#` delimited section at the
 end of the metric, as so:
 
 ```
-metric.name:0|c|#tagName=val,tag2Name=val2
+metric.name:0|c|#tagName:val,tag2Name:val2
 ```
 
 See [Tags](https://docs.datadoghq.com/developers/dogstatsd/data_types/#tagging)


### PR DESCRIPTION
Only `key:value` format for dogstatsd is accepted by latest version of statsd exporter.
I've tried both official client and bash scripts to send the data:

    echo "newpure.test:1|c|@0.5|#country:china" | nc -w 1 -u 127.0.0.1 9125` - will work
    echo "newpure.test:1|c|@0.5|#country=china" | nc -w 1 -u 127.0.0.1 9125 - will not work