### PR TITLE
mapper cache: Use string concatenation rather than Sprintf for formatKey

### DIFF
--- a/pkg/mapper/mapper_cache.go
+++ b/pkg/mapper/mapper_cache.go
@@ -14,8 +14,7 @@
 package mapper
 
 import (
-	"fmt"
-	"github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -81,7 +80,7 @@ func (m *MetricMapperLRUCache) trackCacheLength() {
 }
 
 func formatKey(metricString string, metricType MetricType) string {
-	return fmt.Sprintf("%s.%s", string(metricType), metricString)
+	return string(metricType) + "." + metricString
 }
 
 func NewMetricMapperNoopCache() *MetricMapperNoopCache {


### PR DESCRIPTION
While doing some profiling for something else, I noticed `fmt.Sprintf` in the hot path for cache operations. Changing this to string concatenation gives some improvement in performance.

benchmarked using `go test -bench=BenchmarkGlob100RulesMultipleCapturesCached -benchtime=10s -benchmem`

output from benchcmp:

```
benchmark                                          old ns/op     new ns/op     delta
BenchmarkGlob100RulesMultipleCapturesCached-12     280           158           -43.57%

benchmark                                          old allocs     new allocs     delta
BenchmarkGlob100RulesMultipleCapturesCached-12     4              2              -50.00%

benchmark                                          old bytes     new bytes     delta
BenchmarkGlob100RulesMultipleCapturesCached-12     96            64            -33.33%
```