### PR TITLE
Add random replacement mapper cache 

### DIFF
--- a/pkg/mapper/mapper_benchmark_test.go
+++ b/pkg/mapper/mapper_benchmark_test.go
@@ -15,6 +15,7 @@ package mapper
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
 )
 
@@ -580,17 +581,21 @@ mappings:` + duplicateRules(100, ruleTemplateSingleMatchGlob)
 		"metric100.a",
 	}
 
-	mapper := MetricMapper{}
-	err := mapper.InitFromYAMLString(config, 1000)
-	if err != nil {
-		b.Fatalf("Config load error: %s %s", config, err)
-	}
+	for _, cacheType := range []string{"lru", "random"} {
+		b.Run(cacheType, func(b *testing.B) {
+			mapper := MetricMapper{}
+			err := mapper.InitFromYAMLString(config, 1000, WithCacheType(cacheType))
+			if err != nil {
+				b.Fatalf("Config load error: %s %s", config, err)
+			}
 
-	b.ResetTimer()
-	for j := 0; j < b.N; j++ {
-		for _, metric := range mappings {
-			mapper.GetMapping(metric, MetricTypeCounter)
-		}
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				for _, metric := range mappings {
+					mapper.GetMapping(metric, MetricTypeCounter)
+				}
+			}
+		})
 	}
 }
 
@@ -626,17 +631,21 @@ mappings:` + duplicateRules(10, ruleTemplateSingleMatchRegex)
 		"metric5.a",
 	}
 
-	mapper := MetricMapper{}
-	err := mapper.InitFromYAMLString(config, 1000)
-	if err != nil {
-		b.Fatalf("Config load error: %s %s", config, err)
-	}
+	for _, cacheType := range []string{"lru", "random"} {
+		b.Run(cacheType, func(b *testing.B) {
+			mapper := MetricMapper{}
+			err := mapper.InitFromYAMLString(config, 1000, WithCacheType(cacheType))
+			if err != nil {
+				b.Fatalf("Config load error: %s %s", config, err)
+			}
 
-	b.ResetTimer()
-	for j := 0; j < b.N; j++ {
-		for _, metric := range mappings {
-			mapper.GetMapping(metric, MetricTypeCounter)
-		}
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				for _, metric := range mappings {
+					mapper.GetMapping(metric, MetricTypeCounter)
+				}
+			}
+		})
 	}
 }
 
@@ -668,17 +677,21 @@ mappings:` + duplicateRules(100, ruleTemplateSingleMatchGlob)
 		"metric100.a",
 	}
 
-	mapper := MetricMapper{}
-	err := mapper.InitFromYAMLString(config, 1000)
-	if err != nil {
-		b.Fatalf("Config load error: %s %s", config, err)
-	}
+	for _, cacheType := range []string{"lru", "random"} {
+		b.Run(cacheType, func(b *testing.B) {
+			mapper := MetricMapper{}
+			err := mapper.InitFromYAMLString(config, 1000, WithCacheType(cacheType))
+			if err != nil {
+				b.Fatalf("Config load error: %s %s", config, err)
+			}
 
-	b.ResetTimer()
-	for j := 0; j < b.N; j++ {
-		for _, metric := range mappings {
-			mapper.GetMapping(metric, MetricTypeCounter)
-		}
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				for _, metric := range mappings {
+					mapper.GetMapping(metric, MetricTypeCounter)
+				}
+			}
+		})
 	}
 }
 
@@ -800,17 +813,21 @@ mappings:` + duplicateRules(100, ruleTemplateMultipleMatchGlob)
 		"metric50.a.b.c.d.e.f.g.h.i.j.k.l",
 	}
 
-	mapper := MetricMapper{}
-	err := mapper.InitFromYAMLString(config, 1000)
-	if err != nil {
-		b.Fatalf("Config load error: %s %s", config, err)
-	}
+	for _, cacheType := range []string{"lru", "random"} {
+		b.Run(cacheType, func(b *testing.B) {
+			mapper := MetricMapper{}
+			err := mapper.InitFromYAMLString(config, 1000, WithCacheType(cacheType))
+			if err != nil {
+				b.Fatalf("Config load error: %s %s", config, err)
+			}
 
-	b.ResetTimer()
-	for j := 0; j < b.N; j++ {
-		for _, metric := range mappings {
-			mapper.GetMapping(metric, MetricTypeCounter)
-		}
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				for _, metric := range mappings {
+					mapper.GetMapping(metric, MetricTypeCounter)
+				}
+			}
+		})
 	}
 }
 
@@ -869,16 +886,115 @@ mappings:` + duplicateRules(100, ruleTemplateMultipleMatchRegex)
 		"metric100.a.b.c.d.e.f.g.h.i.j.k.l",
 	}
 
-	mapper := MetricMapper{}
-	err := mapper.InitFromYAMLString(config, 1000)
-	if err != nil {
-		b.Fatalf("Config load error: %s %s", config, err)
+	for _, cacheType := range []string{"lru", "random"} {
+		b.Run(cacheType, func(b *testing.B) {
+			mapper := MetricMapper{}
+			err := mapper.InitFromYAMLString(config, 1000, WithCacheType(cacheType))
+			if err != nil {
+				b.Fatalf("Config load error: %s %s", config, err)
+			}
+
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				for _, metric := range mappings {
+					mapper.GetMapping(metric, MetricTypeCounter)
+				}
+			}
+		})
+	}
+}
+
+func duplicateMetrics(count int, template string) []string {
+	var out []string
+	for i := 0; i < count; i++ {
+		out = append(out, fmt.Sprintf(template, i))
+	}
+	return out
+}
+
+func BenchmarkGlob100RulesCached100Metrics(b *testing.B) {
+	config := `---
+mappings:` + duplicateRules(100, ruleTemplateSingleMatchGlob)
+
+	mappings := duplicateMetrics(100, "metric100")
+
+	for _, cacheType := range []string{"lru", "random"} {
+		b.Run(cacheType, func(b *testing.B) {
+			mapper := MetricMapper{}
+			err := mapper.InitFromYAMLString(config, 1000, WithCacheType(cacheType))
+			if err != nil {
+				b.Fatalf("Config load error: %s %s", config, err)
+			}
+
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				for _, metric := range mappings {
+					mapper.GetMapping(metric, MetricTypeCounter)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkGlob100RulesCached100MetricsSmallCache(b *testing.B) {
+	// This benchmark is the worst case for the LRU cache.
+	// The cache is smaller than the total number of metrics and
+	// we iterate linearly through the metrics, so we will
+	// constantly evict cache entries.
+	config := `---
+mappings:` + duplicateRules(100, ruleTemplateSingleMatchGlob)
+
+	mappings := duplicateMetrics(100, "metric100")
+
+	for _, cacheType := range []string{"lru", "random"} {
+		b.Run(cacheType, func(b *testing.B) {
+			mapper := MetricMapper{}
+			err := mapper.InitFromYAMLString(config, 50, WithCacheType(cacheType))
+			if err != nil {
+				b.Fatalf("Config load error: %s %s", config, err)
+			}
+
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				for _, metric := range mappings {
+					mapper.GetMapping(metric, MetricTypeCounter)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkGlob100RulesCached100MetricsRandomSmallCache(b *testing.B) {
+	// Slighly more realistic benchmark with a smaller cache.
+	// Randomly match metrics so we should have some cache hits.
+	config := `---
+mappings:` + duplicateRules(100, ruleTemplateSingleMatchGlob)
+
+	base := duplicateMetrics(100, "metric100")
+	var mappings []string
+	for i := 0; i < 10; i++ {
+		mappings = append(mappings, base...)
 	}
 
-	b.ResetTimer()
-	for j := 0; j < b.N; j++ {
-		for _, metric := range mappings {
-			mapper.GetMapping(metric, MetricTypeCounter)
-		}
+	r := rand.New(rand.NewSource(42))
+	r.Shuffle(len(mappings), func(i, j int) {
+		mappings[i], mappings[j] = mappings[j], mappings[i]
+	})
+
+	for _, cacheType := range []string{"lru", "random"} {
+		b.Run(cacheType, func(b *testing.B) {
+			mapper := MetricMapper{}
+			err := mapper.InitFromYAMLString(config, 50, WithCacheType(cacheType))
+			if err != nil {
+				b.Fatalf("Config load error: %s %s", config, err)
+			}
+
+			b.ResetTimer()
+			for j := 0; j < b.N; j++ {
+				for _, metric := range mappings {
+					mapper.GetMapping(metric, MetricTypeCounter)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Add a simple random replacement cache based on a map.

Add command line flag to choose mapper cache type, defaulting to existing lru cache.

In the case that all entries fit into the cache, this new cache is faster as it uses a read lock for gets and also has less bookkeeping than the lru cache.

In the case that all entries do not fit into cache, the random replacement cache can avoid thrashing the cache. In some cases, the lru cache will have a very low hit ratio as it is constantly evicting entries.  Our use case is a huge number of unique metric names in "old" statsd format that we map to relatively few Prometheus metrics.

Note: I realize this is probably a much larger change than we may want all at once, but wanted to get feedback on the approach, etc. 

Benchmark results:
```
go test -bench='.*Cache.*' -benchtime=10s -benchmem ./pkg/mapper/

pkg: github.com/prometheus/statsd_exporter/pkg/mapper
BenchmarkGlob10RulesCached/lru-12                           	76762423	       155 ns/op	      48 B/op	       2 allocs/op
BenchmarkGlob10RulesCached/random-12                        	153020101	        78.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkRegex10RulesAverageCached/lru-12                   	78939664	       150 ns/op	      48 B/op	       2 allocs/op
BenchmarkRegex10RulesAverageCached/random-12                	153228613	        78.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkGlob100RulesCached/lru-12                          	78150949	       153 ns/op	      48 B/op	       2 allocs/op
BenchmarkGlob100RulesCached/random-12                       	151522714	        78.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkGlob100RulesMultipleCapturesCached/lru-12          	76434423	       158 ns/op	      64 B/op	       2 allocs/op
BenchmarkGlob100RulesMultipleCapturesCached/random-12       	100000000	       105 ns/op	      48 B/op	       1 allocs/op
BenchmarkRegex100RulesMultipleCapturesWorstCached/lru-12    	75379135	       159 ns/op	      64 B/op	       2 allocs/op
BenchmarkRegex100RulesMultipleCapturesWorstCached/random-12 	100000000	       109 ns/op	      48 B/op	       1 allocs/op
BenchmarkGlob100RulesCached100Metrics/lru-12                	  643710	     18510 ns/op	    6240 B/op	     200 allocs/op
BenchmarkGlob100RulesCached100Metrics/random-12             	 1000000	     10976 ns/op	    4320 B/op	      90 allocs/op
BenchmarkGlob100RulesCached100MetricsSmallCache/lru-12      	   76018	    167613 ns/op	   28502 B/op	    1000 allocs/op
BenchmarkGlob100RulesCached100MetricsSmallCache/random-12   	  128126	     96533 ns/op	   13483 B/op	     446 allocs/op
BenchmarkGlob100RulesCached100MetricsRandomSmallCache/lru-12         	   10000	   1154307 ns/op	  183750 B/op	    6361 allocs/op
BenchmarkGlob100RulesCached100MetricsRandomSmallCache/random-12      	   16196	    731579 ns/op	  108832 B/op	    3478 allocs/op
PASS
ok  	github.com/prometheus/statsd_exporter/pkg/mapper	224.196s
```