### PR TITLE
Rename mapping cache length metric

### DIFF
--- a/pkg/mapper/mapper_cache.go
+++ b/pkg/mapper/mapper_cache.go
@@ -21,7 +21,7 @@ import (
 var (
 	cacheLength = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "statsd_exporter_cache_length",
+			Name: "mapping_cache_length",
 			Help: "The count of unique metrics currently cached.",
 		},
 	)


### PR DESCRIPTION
The mapper package can be used outside the statsd exporter, so it is
better to use generic names here.

follow-up to #280 