### PR TITLE
Use correct name when multiple names match same FSM match

### DIFF
--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -245,7 +245,8 @@ func (m *MetricMapper) GetMapping(statsdMetric string, statsdMetricType MetricTy
 	if m.doFSM {
 		finalState, captures := m.FSM.GetMapping(statsdMetric, string(statsdMetricType))
 		if finalState != nil && finalState.Result != nil {
-			result := finalState.Result.(*MetricMapping)
+			v := finalState.Result.(*MetricMapping)
+			result := copyMetricMapping(v)
 			result.Name = result.nameFormatter.Format(captures)
 
 			labels := prometheus.Labels{}
@@ -298,4 +299,12 @@ func (m *MetricMapper) GetMapping(statsdMetric string, statsdMetricType MetricTy
 
 	m.cache.AddMiss(statsdMetric, statsdMetricType)
 	return nil, nil, false
+}
+
+// make a shallow copy so that we do not overwrite name
+// as multiple names can be matched by same mapping
+func copyMetricMapping(in *MetricMapping) *MetricMapping {
+	var out MetricMapping
+	out = *in
+	return &out
 }


### PR DESCRIPTION
Fixes https://github.com/prometheus/statsd_exporter/issues/273

Make shallow copy of FSM result so that we do not overwrite name.

Before shallow copy:

```
$ go test -v -run='^(TestMultipleMatches)$' ./pkg/mapper/
=== RUN   TestMultipleMatches
--- FAIL: TestMultipleMatches (0.00s)
    mapper_test.go:936: 1:1 Expected name aa_bb_dd_total, got aa_bb_cc_total
FAIL
FAIL	github.com/prometheus/statsd_exporter/pkg/mapper	0.260s
FAIL
```

After shallow copy:
```
$ go test -v -run='^(TestMultipleMatches)$' ./pkg/mapper/
=== RUN   TestMultipleMatches
--- PASS: TestMultipleMatches (0.00s)
PASS
ok  	github.com/prometheus/statsd_exporter/pkg/mapper	(cached)
```