### PR TITLE
Pass logger to UDP listener

### DIFF
--- a/main.go
+++ b/main.go
@@ -198,7 +198,7 @@ func main() {
 			}
 		}
 
-		ul := &StatsDUDPListener{conn: uconn, eventHandler: eventQueue}
+		ul := &StatsDUDPListener{conn: uconn, eventHandler: eventQueue, logger: logger}
 		go ul.Listen()
 	}
 


### PR DESCRIPTION
We were already passing it to the TCP and Unixgram listener, but
somehow left it out of the UDP listener setup.

Fixes #285.

cc @brianirish @yclybouw