### PR TITLE
[DRAFT] move telemetry and expiring registry to separate packages

### DIFF
--- a/event.go
+++ b/event.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"github.com/prometheus/statsd_exporter/pkg/telemetry"
 	"sync"
 	"time"
 
@@ -114,7 +115,7 @@ func (eq *eventQueue) flush() {
 func (eq *eventQueue) flushUnlocked() {
 	eq.c <- eq.q
 	eq.q = make([]Event, 0, cap(eq.q))
-	eventsFlushed.Inc()
+	telemetry.EventsFlushed.Inc()
 }
 
 func (eq *eventQueue) len() int {

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ package main
 import (
 	"bufio"
 	"fmt"
+	"github.com/prometheus/statsd_exporter/pkg/telemetry"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
@@ -115,10 +116,10 @@ func configReloader(fileName string, mapper *mapper.MetricMapper, cacheSize int,
 		err := mapper.InitFromFile(fileName, cacheSize)
 		if err != nil {
 			level.Info(logger).Log("msg", "Error reloading config", "error", err)
-			configLoads.WithLabelValues("failure").Inc()
+			telemetry.ConfigLoads.WithLabelValues("failure").Inc()
 		} else {
 			level.Info(logger).Log("msg", "Config reloaded successfully")
-			configLoads.WithLabelValues("success").Inc()
+			telemetry.ConfigLoads.WithLabelValues("success").Inc()
 		}
 	}
 }
@@ -266,7 +267,7 @@ func main() {
 
 	}
 
-	mapper := &mapper.MetricMapper{MappingsCount: mappingsCount}
+	mapper := &mapper.MetricMapper{MappingsCount: telemetry.MappingsCount}
 	if *mappingConfig != "" {
 		err := mapper.InitFromFile(*mappingConfig, *cacheSize)
 		if err != nil {

--- a/pkg/expiringregistry/expiringregistry_test.go
+++ b/pkg/expiringregistry/expiringregistry_test.go
@@ -1,0 +1,88 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expiringregistry
+
+import "testing"
+
+func TestHashLabelNames(t *testing.T) {
+	r := NewRegistry(nil, nil)
+	// Validate value hash changes and name has doesn't when just the value changes.
+	hash1, _ := r.hashLabels(map[string]string{
+		"label": "value1",
+	})
+	hash2, _ := r.hashLabels(map[string]string{
+		"label": "value2",
+	})
+	if hash1.names != hash2.names {
+		t.Fatal("Hash of label names should match, but doesn't")
+	}
+	if hash1.values == hash2.values {
+		t.Fatal("Hash of label names shouldn't match, but do")
+	}
+
+	// Validate value and name hashes change when the name changes.
+	hash1, _ = r.hashLabels(map[string]string{
+		"label1": "value",
+	})
+	hash2, _ = r.hashLabels(map[string]string{
+		"label2": "value",
+	})
+	if hash1.names == hash2.names {
+		t.Fatal("Hash of label names shouldn't match, but do")
+	}
+	if hash1.values == hash2.values {
+		t.Fatal("Hash of label names shouldn't match, but do")
+	}
+}
+
+func BenchmarkHashNameAndLabels(b *testing.B) {
+	scenarios := []struct {
+		name   string
+		metric string
+		labels map[string]string
+	}{
+		{
+			name:   "no labels",
+			labels: map[string]string{},
+		}, {
+			name: "one label",
+			labels: map[string]string{
+				"label": "value",
+			},
+		}, {
+			name: "many labels",
+			labels: map[string]string{
+				"label0": "value",
+				"label1": "value",
+				"label2": "value",
+				"label3": "value",
+				"label4": "value",
+				"label5": "value",
+				"label6": "value",
+				"label7": "value",
+				"label8": "value",
+				"label9": "value",
+			},
+		},
+	}
+
+	r := NewRegistry(nil, nil)
+	for _, s := range scenarios {
+		b.Run(s.name, func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				r.hashLabels(s.labels)
+			}
+		})
+	}
+}

--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -35,17 +35,17 @@ var (
 	labelNameRE  = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]+$`)
 )
 
-type mapperConfigDefaults struct {
+type MapperConfigDefaults struct {
 	TimerType           TimerType         `yaml:"timer_type"`
 	Buckets             []float64         `yaml:"buckets"`
-	Quantiles           []metricObjective `yaml:"quantiles"`
+	Quantiles           []MetricObjective `yaml:"quantiles"`
 	MatchType           MatchType         `yaml:"match_type"`
 	GlobDisableOrdering bool              `yaml:"glob_disable_ordering"`
 	Ttl                 time.Duration     `yaml:"ttl"`
 }
 
 type MetricMapper struct {
-	Defaults mapperConfigDefaults `yaml:"defaults"`
+	Defaults MapperConfigDefaults `yaml:"defaults"`
 	Mappings []MetricMapping      `yaml:"mappings"`
 	FSM      *fsm.FSM
 	doFSM    bool
@@ -66,7 +66,7 @@ type MetricMapping struct {
 	labelFormatters []*fsm.TemplateFormatter
 	TimerType       TimerType         `yaml:"timer_type"`
 	Buckets         []float64         `yaml:"buckets"`
-	Quantiles       []metricObjective `yaml:"quantiles"`
+	Quantiles       []MetricObjective `yaml:"quantiles"`
 	MatchType       MatchType         `yaml:"match_type"`
 	HelpText        string            `yaml:"help"`
 	Action          ActionType        `yaml:"action"`
@@ -74,12 +74,12 @@ type MetricMapping struct {
 	Ttl             time.Duration     `yaml:"ttl"`
 }
 
-type metricObjective struct {
+type MetricObjective struct {
 	Quantile float64 `yaml:"quantile"`
 	Error    float64 `yaml:"error"`
 }
 
-var defaultQuantiles = []metricObjective{
+var defaultQuantiles = []MetricObjective{
 	{Quantile: 0.5, Error: 0.05},
 	{Quantile: 0.9, Error: 0.01},
 	{Quantile: 0.99, Error: 0.001},

--- a/pkg/mapper/mapper_test.go
+++ b/pkg/mapper/mapper_test.go
@@ -22,7 +22,7 @@ type mappings []struct {
 	statsdMetric string
 	name         string
 	labels       map[string]string
-	quantiles    []metricObjective
+	quantiles    []MetricObjective
 	notPresent   bool
 	ttl          time.Duration
 	metricType   MetricType
@@ -457,7 +457,7 @@ mappings:
 					statsdMetric: "test.*.*",
 					name:         "foo",
 					labels:       map[string]string{},
-					quantiles: []metricObjective{
+					quantiles: []MetricObjective{
 						{Quantile: 0.42, Error: 0.04},
 						{Quantile: 0.7, Error: 0.002},
 					},
@@ -477,7 +477,7 @@ mappings:
 					statsdMetric: "test1.*.*",
 					name:         "foo",
 					labels:       map[string]string{},
-					quantiles: []metricObjective{
+					quantiles: []MetricObjective{
 						{Quantile: 0.5, Error: 0.05},
 						{Quantile: 0.9, Error: 0.01},
 						{Quantile: 0.99, Error: 0.001},

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -11,124 +11,124 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package telemetry
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (
-	eventStats = prometheus.NewCounterVec(
+	EventStats = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "statsd_exporter_events_total",
 			Help: "The total number of StatsD events seen.",
 		},
 		[]string{"type"},
 	)
-	eventsFlushed = prometheus.NewCounter(
+	EventsFlushed = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "statsd_exporter_event_queue_flushed_total",
 			Help: "Number of times events were flushed to exporter",
 		},
 	)
-	eventsUnmapped = prometheus.NewCounter(prometheus.CounterOpts{
+	EventsUnmapped = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "statsd_exporter_events_unmapped_total",
 		Help: "The total number of StatsD events no mapping was found for.",
 	})
-	udpPackets = prometheus.NewCounter(
+	UdpPackets = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "statsd_exporter_udp_packets_total",
 			Help: "The total number of StatsD packets received over UDP.",
 		},
 	)
-	tcpConnections = prometheus.NewCounter(
+	TcpConnections = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "statsd_exporter_tcp_connections_total",
 			Help: "The total number of TCP connections handled.",
 		},
 	)
-	tcpErrors = prometheus.NewCounter(
+	TcpErrors = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "statsd_exporter_tcp_connection_errors_total",
 			Help: "The number of errors encountered reading from TCP.",
 		},
 	)
-	tcpLineTooLong = prometheus.NewCounter(
+	TcpLineTooLong = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "statsd_exporter_tcp_too_long_lines_total",
 			Help: "The number of lines discarded due to being too long.",
 		},
 	)
-	unixgramPackets = prometheus.NewCounter(
+	UnixgramPackets = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "statsd_exporter_unixgram_packets_total",
 			Help: "The total number of StatsD packets received over Unixgram.",
 		},
 	)
-	linesReceived = prometheus.NewCounter(
+	LinesReceived = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "statsd_exporter_lines_total",
 			Help: "The total number of StatsD lines received.",
 		},
 	)
-	samplesReceived = prometheus.NewCounter(
+	SamplesReceived = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "statsd_exporter_samples_total",
 			Help: "The total number of StatsD samples received.",
 		},
 	)
-	sampleErrors = prometheus.NewCounterVec(
+	SampleErrors = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "statsd_exporter_sample_errors_total",
 			Help: "The total number of errors parsing StatsD samples.",
 		},
 		[]string{"reason"},
 	)
-	tagsReceived = prometheus.NewCounter(
+	TagsReceived = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "statsd_exporter_tags_total",
 			Help: "The total number of DogStatsD tags processed.",
 		},
 	)
-	tagErrors = prometheus.NewCounter(
+	TagErrors = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "statsd_exporter_tag_errors_total",
 			Help: "The number of errors parsing DogStatsD tags.",
 		},
 	)
-	configLoads = prometheus.NewCounterVec(
+	ConfigLoads = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "statsd_exporter_config_reloads_total",
 			Help: "The number of configuration reloads.",
 		},
 		[]string{"outcome"},
 	)
-	mappingsCount = prometheus.NewGauge(prometheus.GaugeOpts{
+	MappingsCount = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "statsd_exporter_loaded_mappings",
 		Help: "The current number of configured metric mappings.",
 	})
-	conflictingEventStats = prometheus.NewCounterVec(
+	ConflictingEventStats = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "statsd_exporter_events_conflict_total",
 			Help: "The total number of StatsD events with conflicting names.",
 		},
 		[]string{"type"},
 	)
-	errorEventStats = prometheus.NewCounterVec(
+	ErrorEventStats = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "statsd_exporter_events_error_total",
 			Help: "The total number of StatsD events discarded due to errors.",
 		},
 		[]string{"reason"},
 	)
-	eventsActions = prometheus.NewCounterVec(
+	EventsActions = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "statsd_exporter_events_actions_total",
 			Help: "The total number of StatsD events by action.",
 		},
 		[]string{"action"},
 	)
-	metricsCount = prometheus.NewGaugeVec(
+	MetricsCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "statsd_exporter_metrics_total",
 			Help: "The total number of metrics.",
@@ -138,23 +138,23 @@ var (
 )
 
 func init() {
-	prometheus.MustRegister(eventStats)
-	prometheus.MustRegister(eventsFlushed)
-	prometheus.MustRegister(eventsUnmapped)
-	prometheus.MustRegister(udpPackets)
-	prometheus.MustRegister(tcpConnections)
-	prometheus.MustRegister(tcpErrors)
-	prometheus.MustRegister(tcpLineTooLong)
-	prometheus.MustRegister(unixgramPackets)
-	prometheus.MustRegister(linesReceived)
-	prometheus.MustRegister(samplesReceived)
-	prometheus.MustRegister(sampleErrors)
-	prometheus.MustRegister(tagsReceived)
-	prometheus.MustRegister(tagErrors)
-	prometheus.MustRegister(configLoads)
-	prometheus.MustRegister(mappingsCount)
-	prometheus.MustRegister(conflictingEventStats)
-	prometheus.MustRegister(errorEventStats)
-	prometheus.MustRegister(eventsActions)
-	prometheus.MustRegister(metricsCount)
+	prometheus.MustRegister(EventStats)
+	prometheus.MustRegister(EventsFlushed)
+	prometheus.MustRegister(EventsUnmapped)
+	prometheus.MustRegister(UdpPackets)
+	prometheus.MustRegister(TcpConnections)
+	prometheus.MustRegister(TcpErrors)
+	prometheus.MustRegister(TcpLineTooLong)
+	prometheus.MustRegister(UnixgramPackets)
+	prometheus.MustRegister(LinesReceived)
+	prometheus.MustRegister(SamplesReceived)
+	prometheus.MustRegister(SampleErrors)
+	prometheus.MustRegister(TagsReceived)
+	prometheus.MustRegister(TagErrors)
+	prometheus.MustRegister(ConfigLoads)
+	prometheus.MustRegister(MappingsCount)
+	prometheus.MustRegister(ConflictingEventStats)
+	prometheus.MustRegister(ErrorEventStats)
+	prometheus.MustRegister(EventsActions)
+	prometheus.MustRegister(MetricsCount)
 }


### PR DESCRIPTION
This moves the expiring registry to a separate package so that it can be reused in other projects where an expiring registry might be useful. In addition, it moves telemetry out of the main package and into telemetry since it was low hanging fruit (I can remove this part if it's too much for one PR).

I hacked this up pretty quickly from an internal adaptation of the registry that only used counters and gauges and removed a lot of the defaults, so I am not sure if I got the summary and histogram logic correct when changing from passing in the mapping to a more general API, so double-checking would be greatly appreciated! Additionally, I added a mutex for the expiring registry so it can be used concurrently. The internal adaptation it is based on seems to run fine and the race detector doesn't complain, but I'm not super familiar with the code so I might have missed a lock somewhere. As used in the statsd_exporter, the lock is not necessary, which might add a slight performance hit.

Just looking for some feedback on the general approach and the API for the expiring registry. If all looks good, I'll work on improving the documentation and adding more tests for the new package.

