### PR TITLE
Fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Another capability when using YAML configuration is the ability to define matche
 using raw regular expressions as opposed to the default globbing style of match.
 This may allow for pulling structured data from otherwise poorly named statsd
 metrics AND allow for more precise targetting of match rules. When no `match_type`
-paramter is specified the default value of `glob` will be assumed:
+parameter is specified the default value of `glob` will be assumed:
 
 ```yaml
 mappings:


### PR DESCRIPTION
typo in README.md. I think I got the DCO right this time.

Pinging @matthiasr

Signed-off-by: Elliott Peay <elliott.peay@gmail.com>