### PR TITLE
Allow single-letter components in metric names

### DIFF
--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	statsdMetricRE    = `[a-zA-Z_](-?[a-zA-Z0-9_])+`
+	statsdMetricRE    = `[a-zA-Z_](-?[a-zA-Z0-9_])*`
 	templateReplaceRE = `(\$\{?\d+\}?)`
 
 	metricLineRE = regexp.MustCompile(`^(\*\.|` + statsdMetricRE + `\.)+(\*|` + statsdMetricRE + `)$`)

--- a/pkg/mapper/mapper_test.go
+++ b/pkg/mapper/mapper_test.go
@@ -662,6 +662,29 @@ mappings:
     `,
 			configBad: true,
 		},
+		{
+			config: `---
+mappings:
+- match: p.*.*.c.*
+  match_type: glob
+  name: issue_256
+  labels:
+    one: $1
+    two: $2
+    three: $3
+`,
+			mappings: mappings{
+				{
+					statsdMetric: "p.one.two.c.three",
+					name:         "issue_256",
+					labels: map[string]string{
+						"one":   "one",
+						"two":   "two",
+						"three": "three",
+					},
+				},
+			},
+		},
 		// Example from the README.
 		{
 			config: `


### PR DESCRIPTION
They are valid. Fixes #256.

@mizhka is this what you meant?