### PR TITLE
[268] Support SignalFx Tags

### DIFF
--- a/bridge_test.go
+++ b/bridge_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+
 	"github.com/prometheus/statsd_exporter/pkg/clock"
 	"github.com/prometheus/statsd_exporter/pkg/event"
 	"github.com/prometheus/statsd_exporter/pkg/exporter"
@@ -282,6 +283,10 @@ func TestHandlePacket(t *testing.T) {
 		}, {
 			name: "librato/dogstatsd mixed tag styles without sampling",
 			in:   "foo#tag1=foo,tag3=bing:100|c|#tag1:bar,#tag2:baz",
+			out:  event.Events{},
+		}, {
+			name: "signalfx/dogstatsd mixed tag styles without sampling",
+			in:   "foo[tag1=foo,tag3=bing]:100|c|#tag1:bar,#tag2:baz",
 			out:  event.Events{},
 		}, {
 			name: "influxdb/dogstatsd mixed tag styles without sampling",

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -221,6 +221,26 @@ func TestHandlePacket(t *testing.T) {
 				},
 			},
 		}, {
+			name: "SignalFx tag extension, missing closing bracket",
+			in:   "[tag1=bar,tag2=bazfoo.test:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "[tag1=bar,tag2=bazfoo.test",
+					CValue:      100,
+					CLabels:     map[string]string{},
+				},
+			},
+		}, {
+			name: "SignalFx tag extension, missing opening bracket",
+			in:   "tag1=bar,tag2=baz]foo.test:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "tag1=bar,tag2=baz]foo.test",
+					CValue:      100,
+					CLabels:     map[string]string{},
+				},
+			},
+		}, {
 			name: "influxdb tag extension with tag keys unsupported by prometheus",
 			in:   "foo,09digits=0,tag.with.dots=1:100|c",
 			out: event.Events{

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -180,6 +180,26 @@ func TestHandlePacket(t *testing.T) {
 				},
 			},
 		}, {
+			name: "SignalFx tag extension, tags at end of name",
+			in:   "foo.test[tag1=bar,tag2=baz]:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo.test",
+					CValue:      100,
+					CLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		}, {
+			name: "SignalFx tag extension, tags at beginning of name",
+			in:   "[tag1=bar,tag2=baz]foo.test:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo.test",
+					CValue:      100,
+					CLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		}, {
 			name: "influxdb tag extension with tag keys unsupported by prometheus",
 			in:   "foo,09digits=0,tag.with.dots=1:100|c",
 			out: event.Events{

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -201,6 +201,26 @@ func TestHandlePacket(t *testing.T) {
 				},
 			},
 		}, {
+			name: "SignalFx tag extension, no tags",
+			in:   "foo.[]test:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo.test",
+					CValue:      100,
+					CLabels:     map[string]string{},
+				},
+			},
+		}, {
+			name: "SignalFx tag extension, non-kv tags",
+			in:   "foo.[tag1,tag2]test:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo.test",
+					CValue:      100,
+					CLabels:     map[string]string{},
+				},
+			},
+		}, {
 			name: "influxdb tag extension with tag keys unsupported by prometheus",
 			in:   "foo,09digits=0,tag.with.dots=1:100|c",
 			out: event.Events{

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -170,6 +170,16 @@ func TestHandlePacket(t *testing.T) {
 				},
 			},
 		}, {
+			name: "SignalFx tag extension",
+			in:   "foo.[tag1=bar,tag2=baz]test:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo.test",
+					CValue:      100,
+					CLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		}, {
 			name: "influxdb tag extension with tag keys unsupported by prometheus",
 			in:   "foo,09digits=0,tag.with.dots=1:100|c",
 			out: event.Events{

--- a/line_benchmark_test.go
+++ b/line_benchmark_test.go
@@ -38,7 +38,6 @@ func benchmarkLineToEvents(times int, b *testing.B) {
 	logger := log.NewNopLogger()
 
 	for n := 0; n < b.N; n++ {
-
 		for i := 0; i < times; i++ {
 			for _, l := range input {
 				line.LineToEvents(l, *sampleErrors, samplesReceived, tagErrors, tagsReceived, logger)

--- a/line_benchmark_test.go
+++ b/line_benchmark_test.go
@@ -47,7 +47,6 @@ func benchmarkLineToEvents(times int, b *testing.B) {
 	}
 }
 
-
 func BenchmarkLineToEvents1(b *testing.B) {
 	benchmarkLineToEvents(1, b)
 }

--- a/line_benchmark_test.go
+++ b/line_benchmark_test.go
@@ -1,0 +1,59 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/go-kit/kit/log"
+
+	"github.com/prometheus/statsd_exporter/pkg/line"
+)
+
+func benchmarkLineToEvents(times int, b *testing.B) {
+	input := []string{
+		"foo1:2|c",
+		"foo2:3|g",
+		"foo3:200|ms",
+		"foo4:100|c|#tag1:bar,tag2:baz",
+		"foo5:100|c|#tag1:bar,#tag2:baz",
+		"foo6:100|c|#09digits:0,tag.with.dots:1",
+		"foo10:100|c|@0.1|#tag1:bar,#tag2:baz",
+		"foo11:100|c|@0.1|#tag1:foo:bar",
+		"foo.[foo=bar,dim=val]test:1|g",
+		"foo15:200|ms:300|ms:5|c|@0.1:6|g\nfoo15a:1|c:5|ms",
+		"some_very_useful_metrics_with_quite_a_log_name:13|c",
+	}
+	logger := log.NewNopLogger()
+
+	for n := 0; n < b.N; n++ {
+
+		for i := 0; i < times; i++ {
+			for _, l := range input {
+				line.LineToEvents(l, *sampleErrors, samplesReceived, tagErrors, tagsReceived, logger)
+			}
+		}
+	}
+}
+
+
+func BenchmarkLineToEvents1(b *testing.B) {
+	benchmarkLineToEvents(1, b)
+}
+func BenchmarkLineToEvents5(b *testing.B) {
+	benchmarkLineToEvents(5, b)
+}
+func BenchmarkLineToEvents50(b *testing.B) {
+	benchmarkLineToEvents(50, b)
+}

--- a/pkg/line/line.go
+++ b/pkg/line/line.go
@@ -139,9 +139,16 @@ func parseNameAndTags(name string, labels map[string]string, tagErrors prometheu
 	startIdx := strings.IndexRune(name, '[')
 	endIdx := strings.IndexRune(name, ']')
 
-	if startIdx != -1 && endIdx != -1 {
+	switch {
+	case startIdx != -1 && endIdx != -1:
+		// good signalfx tags
 		parseNameTags(name[startIdx+1:endIdx], labels, tagErrors, logger)
 		return name[:startIdx] + name[endIdx+1:]
+	case (startIdx != -1) != (endIdx != -1):
+		// only one bracket, return unparsed
+		level.Debug(logger).Log("msg", "invalid SignalFx tags, not parsing", "metric", name)
+		tagErrors.Inc()
+		return name
 	}
 
 	for i, c := range name {


### PR DESCRIPTION
Adds parsing for SignalFX-style tagsand a benchmark for LineToEvents. Fixes #268. It's unclear from the signalfx docs, but it appears that the tags can exist anywhere in the name field, making parsing a little more complicated.

There is a definite slight cost to parsing these tags since they can be in the middle of the name, and have opening and closing runes.

Before:
```
go test -bench='BenchmarkLineToEvents(1|5|50)'                                                                                                                
goos: darwin
goarch: amd64
pkg: github.com/prometheus/statsd_exporter
BenchmarkLineToEvents1-12         148065              7847 ns/op
BenchmarkLineToEvents5-12          30534             39436 ns/op
BenchmarkLineToEvents50-12          3038            392718 ns/op
PASS
ok      github.com/prometheus/statsd_exporter   4.261s

```

After:
```
go test -bench='BenchmarkLineToEvents(1|5|50)'                                                                                                                 
goos: darwin
goarch: amd64
pkg: github.com/prometheus/statsd_exporter
BenchmarkLineToEvents1-12         132652              8131 ns/op
BenchmarkLineToEvents5-12          29119             40593 ns/op
BenchmarkLineToEvents50-12          2988            405923 ns/op
PASS
ok      github.com/prometheus/statsd_exporter   4.357s

```