### PR TITLE
improve benchmark validity by not measuring startup costs

### DIFF
--- a/line_benchmark_test.go
+++ b/line_benchmark_test.go
@@ -37,6 +37,9 @@ func benchmarkLineToEvents(times int, b *testing.B) {
 	}
 	logger := log.NewNopLogger()
 
+	// reset benchmark timer to not measure startup costs
+	b.ResetTimer()
+
 	for n := 0; n < b.N; n++ {
 		for i := 0; i < times; i++ {
 			for _, l := range input {


### PR DESCRIPTION
Modify benchmarks to not measure startup costs - https://dave.cheney.net/high-performance-go-workshop/dotgo-paris.html#avoiding_benchmarking_start_up_costs

This doesn't seem to affect the benchmark results too much, but seems more correct.

@matthiasr 