### PR TITLE
break out line benchmarks by format

### DIFF
--- a/line_benchmark_test.go
+++ b/line_benchmark_test.go
@@ -21,8 +21,9 @@ import (
 	"github.com/prometheus/statsd_exporter/pkg/line"
 )
 
-func benchmarkLineToEvents(times int, b *testing.B) {
-	input := []string{
+var (
+	// just a grab bag of mixed formats, valid, invalid
+	mixedLines = []string{
 		"foo1:2|c",
 		"foo2:3|g",
 		"foo3:200|ms",
@@ -35,10 +36,23 @@ func benchmarkLineToEvents(times int, b *testing.B) {
 		"foo15:200|ms:300|ms:5|c|@0.1:6|g\nfoo15a:1|c:5|ms",
 		"some_very_useful_metrics_with_quite_a_log_name:13|c",
 	}
-	logger := log.NewNopLogger()
 
-	// reset benchmark timer to not measure startup costs
-	b.ResetTimer()
+	// The format specific lines have only one line each so the benchmark accurately reflects the time taken to process one line
+	statsdLine           = "foo1:2|c"
+	statsdInvalidLine    = "foo1:2|c||"
+	dogStatsdLine        = "foo1:100|c|#tag1:bar,tag2:baz"
+	dogStatsdInvalidLine = "foo3:100|c|#09digits:0,tag.with.dots:1"
+	signalFxLine         = "foo1.[foo=bar1,dim=val1]test:1|g"
+	signalFxInvalidLine  = "foo1.[foo=bar1,dim=val1test:1|g"
+	influxDbLine         = "foo1,tag1=bar,tag2=baz:100|c"
+	influxDbInvalidLine  = "foo3,tag1=bar,tag2:100|c"
+
+	logger = log.NewNopLogger()
+)
+
+func benchmarkLinesToEvents(times int, b *testing.B, input []string) {
+	// always report allocations since this is a hot path
+	b.ReportAllocs()
 
 	for n := 0; n < b.N; n++ {
 		for i := 0; i < times; i++ {
@@ -49,12 +63,51 @@ func benchmarkLineToEvents(times int, b *testing.B) {
 	}
 }
 
-func BenchmarkLineToEvents1(b *testing.B) {
-	benchmarkLineToEvents(1, b)
+func benchmarkLineToEvents(b *testing.B, inputLine string) {
+	// always report allocations since this is a hot path
+	b.ReportAllocs()
+
+	for n := 0; n < b.N; n++ {
+		line.LineToEvents(inputLine, *sampleErrors, samplesReceived, tagErrors, tagsReceived, logger)
+	}
 }
-func BenchmarkLineToEvents5(b *testing.B) {
-	benchmarkLineToEvents(5, b)
+
+// Mixed statsd formats
+func BenchmarkLineToEventsMixed1(b *testing.B) {
+	benchmarkLinesToEvents(1, b, mixedLines)
 }
-func BenchmarkLineToEvents50(b *testing.B) {
-	benchmarkLineToEvents(50, b)
+func BenchmarkLineToEventsMixed5(b *testing.B) {
+	benchmarkLinesToEvents(5, b, mixedLines)
+}
+func BenchmarkLineToEventsMixed50(b *testing.B) {
+	benchmarkLinesToEvents(50, b, mixedLines)
+}
+
+// Individual format benchmarks
+// Valid Lines
+func BenchmarkLineToEventsStatsd(b *testing.B) {
+	benchmarkLineToEvents(b, statsdLine)
+}
+func BenchmarkLineToEventsDogStatsd(b *testing.B) {
+	benchmarkLineToEvents(b, dogStatsdLine)
+}
+func BenchmarkLineToEventsSignalFx(b *testing.B) {
+	benchmarkLineToEvents(b, signalFxLine)
+}
+func BenchmarkLineToEventsInfluxDb(b *testing.B) {
+	benchmarkLineToEvents(b, influxDbLine)
+}
+
+// Invalid lines
+func BenchmarkLineToEventsStatsdInvalid(b *testing.B) {
+	benchmarkLineToEvents(b, statsdInvalidLine)
+}
+func BenchmarkLineToEventsDogStatsdInvalid(b *testing.B) {
+	benchmarkLineToEvents(b, dogStatsdInvalidLine)
+}
+func BenchmarkLineToEventsSignalFxInvalid(b *testing.B) {
+	benchmarkLineToEvents(b, signalFxInvalidLine)
+}
+func BenchmarkLineToEventsInfluxDbInvalid(b *testing.B) {
+	benchmarkLineToEvents(b, influxDbInvalidLine)
 }


### PR DESCRIPTION
This breaks out the line benchmarks by format, only tests one line per iteration so that the benchmark results reflect the time taken to parse one line, and always reports allocations for the line benchmark.  This should make it easier to spot changes in line parsing.

```
$ go test -bench=BenchmarkLineToEvents. 
goos: darwin
goarch: amd64
pkg: github.com/prometheus/statsd_exporter
BenchmarkLineToEventsMixed1-12                    143725              8279 ns/op            4778 B/op         91 allocs/op
BenchmarkLineToEventsMixed5-12                     30028             40079 ns/op           23892 B/op        455 allocs/op
BenchmarkLineToEventsMixed50-12                     2978            403951 ns/op          238924 B/op       4550 allocs/op
BenchmarkLineToEventsStatsd-12                   3039831               390 ns/op             176 B/op          6 allocs/op
BenchmarkLineToEventsDogStatsd-12                2069989               581 ns/op             464 B/op          6 allocs/op
BenchmarkLineToEventsSignalFx-12                 1892844               632 ns/op             496 B/op          8 allocs/op
BenchmarkLineToEventsInfluxDb-12                 2002430               606 ns/op             464 B/op          7 allocs/op
BenchmarkLineToEventsStatsdInvalid-12            1645948               727 ns/op             432 B/op         10 allocs/op
BenchmarkLineToEventsDogStatsdInvalid-12         1672852               719 ns/op             496 B/op          8 allocs/op
BenchmarkLineToEventsSignalFxInvalid-12          1713837               693 ns/op             448 B/op         11 allocs/op
BenchmarkLineToEventsInfluxDbInvalid-12          1352252               880 ns/op             800 B/op         13 allocs/op
PASS
ok      github.com/prometheus/statsd_exporter   20.358s

```

@matthiasr 