### PR TITLE
Disable tags

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/prometheus/statsd_exporter/pkg/address"
 	"github.com/prometheus/statsd_exporter/pkg/event"
 	"github.com/prometheus/statsd_exporter/pkg/exporter"
+	"github.com/prometheus/statsd_exporter/pkg/line"
 	"github.com/prometheus/statsd_exporter/pkg/listener"
 	"github.com/prometheus/statsd_exporter/pkg/mapper"
 )
@@ -268,6 +269,10 @@ func main() {
 		eventFlushInterval   = kingpin.Flag("statsd.event-flush-interval", "Number of events to hold in queue before flushing").Default("200ms").Duration()
 		dumpFSMPath          = kingpin.Flag("debug.dump-fsm", "The path to dump internal FSM generated for glob matching as Dot file.").Default("").String()
 		checkConfig          = kingpin.Flag("check-config", "Check configuration and exit.").Default("false").Bool()
+		dogstatsdTagsEnabled = kingpin.Flag("statsd.dogstatsd-tags-enabled", "Parse DogStatsd style tags").Default("true").Bool()
+		influxdbTagsEnabled  = kingpin.Flag("statsd.influxdb-tags-enabled", "Parse InfluxDB style tags").Default("true").Bool()
+		libratoTagsEnabled   = kingpin.Flag("statsd.librato-tags-enabled", "Parse Librato style tags").Default("true").Bool()
+		signalFXTagsEnabled  = kingpin.Flag("statsd.signalfx-tags-enabled", "Parse SignalFX style tags").Default("true").Bool()
 	)
 
 	promlogConfig := &promlog.Config{}
@@ -276,6 +281,12 @@ func main() {
 	kingpin.HelpFlag.Short('h')
 	kingpin.Parse()
 	logger := promlog.New(promlogConfig)
+
+	// Set line parsing options
+	line.DogstatsdTagsEnabled = *dogstatsdTagsEnabled
+	line.InfluxdbTagsEnabled = *influxdbTagsEnabled
+	line.LibratoTagsEnabled = *libratoTagsEnabled
+	line.SignalFXTagsEnabled = *signalFXTagsEnabled
 
 	cacheOption := mapper.WithCacheType(*cacheType)
 

--- a/pkg/line/line_test.go
+++ b/pkg/line/line_test.go
@@ -1,0 +1,749 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package line
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/prometheus/statsd_exporter/pkg/event"
+)
+
+var (
+	nopSamplesReceived = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "statsd_exporter_samples_total",
+			Help: "The total number of StatsD samples received.",
+		},
+	)
+	nopSampleErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "statsd_exporter_sample_errors_total",
+			Help: "The total number of errors parsing StatsD samples.",
+		},
+		[]string{"reason"},
+	)
+	nopTagsReceived = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "statsd_exporter_tags_total",
+			Help: "The total number of DogStatsD tags processed.",
+		},
+	)
+	nopTagErrors = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "statsd_exporter_tag_errors_total",
+			Help: "The number of errors parsing DogStatsD tags.",
+		},
+	)
+	nopLogger = log.NewNopLogger()
+)
+
+func TestLineToEvents(t *testing.T) {
+	type testCase struct {
+		in  string
+		out event.Events
+	}
+
+	testCases := map[string]testCase{
+		"empty": {},
+		"simple counter": {
+			in: "foo:2|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo",
+					CValue:      2,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"simple gauge": {
+			in: "foo:3|g",
+			out: event.Events{
+				&event.GaugeEvent{
+					GMetricName: "foo",
+					GValue:      3,
+					GLabels:     map[string]string{},
+				},
+			},
+		},
+		"gauge with sampling": {
+			in: "foo:3|g|@0.2",
+			out: event.Events{
+				&event.GaugeEvent{
+					GMetricName: "foo",
+					GValue:      3,
+					GLabels:     map[string]string{},
+				},
+			},
+		},
+		"gauge decrement": {
+			in: "foo:-10|g",
+			out: event.Events{
+				&event.GaugeEvent{
+					GMetricName: "foo",
+					GValue:      -10,
+					GRelative:   true,
+					GLabels:     map[string]string{},
+				},
+			},
+		},
+		"simple timer": {
+			in: "foo:200|ms",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo",
+					OValue:      0.2,
+					OLabels:     map[string]string{},
+				},
+			},
+		},
+		"simple histogram": {
+			in: "foo:200|h",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo",
+					OValue:      200,
+					OLabels:     map[string]string{},
+				},
+			},
+		},
+		"simple distribution": {
+			in: "foo:200|d",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo",
+					OValue:      200,
+					OLabels:     map[string]string{},
+				},
+			},
+		},
+		"distribution with sampling": {
+			in: "foo:0.01|d|@0.2|#tag1:bar,#tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		},
+		"librato tag extension": {
+			in: "foo#tag1=bar,tag2=baz:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo",
+					CValue:      100,
+					CLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		},
+		"librato tag extension with tag keys unsupported by prometheus": {
+			in: "foo#09digits=0,tag.with.dots=1:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo",
+					CValue:      100,
+					CLabels:     map[string]string{"_09digits": "0", "tag_with_dots": "1"},
+				},
+			},
+		},
+		"influxdb tag extension": {
+			in: "foo,tag1=bar,tag2=baz:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo",
+					CValue:      100,
+					CLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		},
+		"SignalFx tag extension": {
+			in: "foo.[tag1=bar,tag2=baz]test:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo.test",
+					CValue:      100,
+					CLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		},
+		"SignalFx tag extension, tags at end of name": {
+			in: "foo.test[tag1=bar,tag2=baz]:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo.test",
+					CValue:      100,
+					CLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		},
+		"SignalFx tag extension, tags at beginning of name": {
+			in: "[tag1=bar,tag2=baz]foo.test:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo.test",
+					CValue:      100,
+					CLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		},
+		"SignalFx tag extension, no tags": {
+			in: "foo.[]test:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo.test",
+					CValue:      100,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"SignalFx tag extension, non-kv tags": {
+			in: "foo.[tag1,tag2]test:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo.test",
+					CValue:      100,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"SignalFx tag extension, missing closing bracket": {
+			in: "[tag1=bar,tag2=bazfoo.test:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "[tag1=bar,tag2=bazfoo.test",
+					CValue:      100,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"SignalFx tag extension, missing opening bracket": {
+			in: "tag1=bar,tag2=baz]foo.test:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "tag1=bar,tag2=baz]foo.test",
+					CValue:      100,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"influxdb tag extension with tag keys unsupported by prometheus": {
+			in: "foo,09digits=0,tag.with.dots=1:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo",
+					CValue:      100,
+					CLabels:     map[string]string{"_09digits": "0", "tag_with_dots": "1"},
+				},
+			},
+		},
+		"datadog tag extension": {
+			in: "foo:100|c|#tag1:bar,tag2:baz",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo",
+					CValue:      100,
+					CLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		},
+		"datadog tag extension with # in all keys (as sent by datadog php client)": {
+			in: "foo:100|c|#tag1:bar,#tag2:baz",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo",
+					CValue:      100,
+					CLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		},
+		"datadog tag extension with tag keys unsupported by prometheus": {
+			in: "foo:100|c|#09digits:0,tag.with.dots:1",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo",
+					CValue:      100,
+					CLabels:     map[string]string{"_09digits": "0", "tag_with_dots": "1"},
+				},
+			},
+		},
+		"datadog tag extension with valueless tags: ignored": {
+			in: "foo:100|c|#tag_without_a_value",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo",
+					CValue:      100,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog tag extension with valueless tags (edge case)": {
+			in: "foo:100|c|#tag_without_a_value,tag:value",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo",
+					CValue:      100,
+					CLabels:     map[string]string{"tag": "value"},
+				},
+			},
+		},
+		"datadog tag extension with empty tags (edge case)": {
+			in: "foo:100|c|#tag:value,,",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo",
+					CValue:      100,
+					CLabels:     map[string]string{"tag": "value"},
+				},
+			},
+		},
+		"datadog tag extension with sampling": {
+			in: "foo:100|c|@0.1|#tag1:bar,#tag2:baz",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo",
+					CValue:      1000,
+					CLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		},
+		"librato/dogstatsd mixed tag styles without sampling": {
+			in:  "foo#tag1=foo,tag3=bing:100|c|#tag1:bar,#tag2:baz",
+			out: event.Events{},
+		},
+		"signalfx/dogstatsd mixed tag styles without sampling": {
+			in:  "foo[tag1=foo,tag3=bing]:100|c|#tag1:bar,#tag2:baz",
+			out: event.Events{},
+		},
+		"influxdb/dogstatsd mixed tag styles without sampling": {
+			in:  "foo,tag1=foo,tag3=bing:100|c|#tag1:bar,#tag2:baz",
+			out: event.Events{},
+		},
+		"mixed tag styles with sampling": {
+			in:  "foo#tag1=foo,tag3=bing:100|c|@0.1|#tag1:bar,#tag2:baz",
+			out: event.Events{},
+		},
+		"histogram with sampling": {
+			in: "foo:0.01|h|@0.2|#tag1:bar,#tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		},
+		"datadog tag extension with multiple colons": {
+			in: "foo:100|c|@0.1|#tag1:foo:bar",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo",
+					CValue:      1000,
+					CLabels:     map[string]string{"tag1": "foo:bar"},
+				},
+			},
+		},
+		"datadog tag extension with invalid utf8 tag values": {
+			in: "foo:100|c|@0.1|#tag:\xc3\x28invalid",
+		},
+		"datadog tag extension with both valid and invalid utf8 tag values": {
+			in: "foo:100|c|@0.1|#tag1:valid,tag2:\xc3\x28invalid",
+		},
+		"timings with sampling factor": {
+			in: "foo.timing:0.5|ms|@0.1",
+			out: event.Events{
+				&event.ObserverEvent{OMetricName: "foo.timing", OValue: 0.0005, OLabels: map[string]string{}},
+				&event.ObserverEvent{OMetricName: "foo.timing", OValue: 0.0005, OLabels: map[string]string{}},
+				&event.ObserverEvent{OMetricName: "foo.timing", OValue: 0.0005, OLabels: map[string]string{}},
+				&event.ObserverEvent{OMetricName: "foo.timing", OValue: 0.0005, OLabels: map[string]string{}},
+				&event.ObserverEvent{OMetricName: "foo.timing", OValue: 0.0005, OLabels: map[string]string{}},
+				&event.ObserverEvent{OMetricName: "foo.timing", OValue: 0.0005, OLabels: map[string]string{}},
+				&event.ObserverEvent{OMetricName: "foo.timing", OValue: 0.0005, OLabels: map[string]string{}},
+				&event.ObserverEvent{OMetricName: "foo.timing", OValue: 0.0005, OLabels: map[string]string{}},
+				&event.ObserverEvent{OMetricName: "foo.timing", OValue: 0.0005, OLabels: map[string]string{}},
+				&event.ObserverEvent{OMetricName: "foo.timing", OValue: 0.0005, OLabels: map[string]string{}},
+			},
+		},
+		"bad line": {
+			in: "foo",
+		},
+		"bad component": {
+			in: "foo:1",
+		},
+		"bad value": {
+			in: "foo:1o|c",
+		},
+		"illegal sampling factor": {
+			in: "foo:1|c|@bar",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo",
+					CValue:      1,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"zero sampling factor": {
+			in: "foo:2|c|@0",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo",
+					CValue:      2,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"illegal stat type": {
+			in: "foo:2|t",
+		},
+		"empty metric name": {
+			in: ":100|ms",
+		},
+		"empty component": {
+			in: "foo:1|c|",
+		},
+		"invalid utf8": {
+			in: "invalid\xc3\x28utf8:1|c",
+		},
+		"ms timer with conversion to seconds": {
+			in: "foo:200|ms",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo",
+					OValue:      0.2,
+					OLabels:     map[string]string{},
+				},
+			},
+		},
+		"histogram with no unit conversion": {
+			in: "foo:200|h",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo",
+					OValue:      200,
+					OLabels:     map[string]string{},
+				},
+			},
+		},
+		"distribution with no unit conversion": {
+			in: "foo:200|d",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo",
+					OValue:      200,
+					OLabels:     map[string]string{},
+				},
+			},
+		},
+	}
+
+	DogstatsdTagsEnabled = true
+	InfluxdbTagsEnabled = true
+	SignalFXTagsEnabled = true
+	LibratoTagsEnabled = true
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			events := LineToEvents(testCase.in, *nopSampleErrors, nopSamplesReceived, nopTagErrors, nopTagsReceived, nopLogger)
+
+			for j, expected := range testCase.out {
+				if !reflect.DeepEqual(&expected, &events[j]) {
+					t.Fatalf("Expected %#v, got %#v in scenario '%s'", expected, events[j], name)
+				}
+			}
+		})
+	}
+}
+
+func TestDisableParsingLineToEvents(t *testing.T) {
+	type testCase struct {
+		in  string
+		out event.Events
+	}
+
+	testCases := map[string]testCase{
+		"librato tag extension": {
+			in: "foo#tag1=bar,tag2=baz:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo#tag1=bar,tag2=baz",
+					CValue:      100,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"librato tag extension with tag keys unsupported by prometheus": {
+			in: "foo#09digits=0,tag.with.dots=1:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo#09digits=0,tag.with.dots=1",
+					CValue:      100,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"influxdb tag extension": {
+			in: "foo,tag1=bar,tag2=baz:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo,tag1=bar,tag2=baz",
+					CValue:      100,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"SignalFx tag extension": {
+			in: "foo.[tag1=bar,tag2=baz]test:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo.[tag1=bar,tag2=baz]test",
+					CValue:      100,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"SignalFx tag extension, tags at end of name": {
+			in: "foo.test[tag1=bar,tag2=baz]:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo.test[tag1=bar,tag2=baz]",
+					CValue:      100,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"SignalFx tag extension, tags at beginning of name": {
+			in: "[tag1=bar,tag2=baz]foo.test:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "[tag1=bar,tag2=baz]foo.test",
+					CValue:      100,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"SignalFx tag extension, no tags": {
+			in: "foo.[]test:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo.[]test",
+					CValue:      100,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"SignalFx tag extension, non-kv tags": {
+			in: "foo.[tag1,tag2]test:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo.[tag1,tag2]test",
+					CValue:      100,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"SignalFx tag extension, missing closing bracket": {
+			in: "[tag1=bar,tag2=bazfoo.test:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "[tag1=bar,tag2=bazfoo.test",
+					CValue:      100,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"SignalFx tag extension, missing opening bracket": {
+			in: "tag1=bar,tag2=baz]foo.test:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "tag1=bar,tag2=baz]foo.test",
+					CValue:      100,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"influxdb tag extension with tag keys unsupported by prometheus": {
+			in: "foo,09digits=0,tag.with.dots=1:100|c",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo,09digits=0,tag.with.dots=1",
+					CValue:      100,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog tag extension": {
+			in: "foo:100|c|#tag1:bar,tag2:baz",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo",
+					CValue:      100,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog tag extension with # in all keys (as sent by datadog php client)": {
+			in: "foo:100|c|#tag1:bar,#tag2:baz",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo",
+					CValue:      100,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog tag extension with tag keys unsupported by prometheus": {
+			in: "foo:100|c|#09digits:0,tag.with.dots:1",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo",
+					CValue:      100,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog tag extension with valueless tags: ignored": {
+			in: "foo:100|c|#tag_without_a_value",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo",
+					CValue:      100,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog tag extension with valueless tags (edge case)": {
+			in: "foo:100|c|#tag_without_a_value,tag:value",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo",
+					CValue:      100,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog tag extension with empty tags (edge case)": {
+			in: "foo:100|c|#tag:value,,",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo",
+					CValue:      100,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog tag extension with sampling": {
+			in: "foo:100|c|@0.1|#tag1:bar,#tag2:baz",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo",
+					CValue:      1000,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"librato/dogstatsd mixed tag styles without sampling": {
+			in:  "foo#tag1=foo,tag3=bing:100|c|#tag1:bar,#tag2:baz",
+			out: event.Events{},
+		},
+		"signalfx/dogstatsd mixed tag styles without sampling": {
+			in:  "foo[tag1=foo,tag3=bing]:100|c|#tag1:bar,#tag2:baz",
+			out: event.Events{},
+		},
+		"influxdb/dogstatsd mixed tag styles without sampling": {
+			in:  "foo,tag1=foo,tag3=bing:100|c|#tag1:bar,#tag2:baz",
+			out: event.Events{},
+		},
+		"mixed tag styles with sampling": {
+			in:  "foo#tag1=foo,tag3=bing:100|c|@0.1|#tag1:bar,#tag2:baz",
+			out: event.Events{},
+		},
+		"datadog tag extension with multiple colons": {
+			in: "foo:100|c|@0.1|#tag1:foo:bar",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo",
+					CValue:      1000,
+					CLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog tag extension with invalid utf8 tag values": {
+			in: "foo:100|c|@0.1|#tag:\xc3\x28invalid",
+		},
+		"datadog tag extension with both valid and invalid utf8 tag values": {
+			in: "foo:100|c|@0.1|#tag1:valid,tag2:\xc3\x28invalid",
+		},
+	}
+
+	DogstatsdTagsEnabled = false
+	InfluxdbTagsEnabled = false
+	SignalFXTagsEnabled = false
+	LibratoTagsEnabled = false
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			events := LineToEvents(testCase.in, *nopSampleErrors, nopSamplesReceived, nopTagErrors, nopTagsReceived, nopLogger)
+
+			for j, expected := range testCase.out {
+				if !reflect.DeepEqual(&expected, &events[j]) {
+					t.Fatalf("Expected %#v, got %#v in scenario '%s'", expected, events[j], name)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds globals to the line package to allow disabling of individual tag parsing formats and unit tests for the line package. I don't love using package globals for this, but it does maintain backwards compatibility with the package, and is cleaner than adding four more parameters to the lineToEvents function. Open to other suggestions. Fixes #324 

Before:
```
$ go test -bench=BenchmarkLine.
goos: darwin
goarch: amd64
pkg: github.com/prometheus/statsd_exporter
BenchmarkLineToEventsMixed1-12            142213              9420 ns/op            4778 B/op         91 allocs/op
BenchmarkLineToEventsMixed5-12             28290             40648 ns/op           23892 B/op        455 allocs/op
BenchmarkLineToEventsMixed50-12             2908            426202 ns/op          238924 B/op       4550 allocs/op
BenchmarkLineFormats/dogStatsd-12        1870549               623 ns/op             464 B/op          6 allocs/op
BenchmarkLineFormats/invalidDogStatsd-12                 1575892               710 ns/op             496 B/op          8 allocs/op
BenchmarkLineFormats/signalFx-12                         1847803               675 ns/op             496 B/op          8 allocs/op
BenchmarkLineFormats/invalidSignalFx-12                  1661490               708 ns/op             448 B/op         11 allocs/op
BenchmarkLineFormats/influxDb-12                         1805835               614 ns/op             464 B/op          7 allocs/op
BenchmarkLineFormats/invalidInfluxDb-12                  1348052               890 ns/op             800 B/op         13 allocs/op
BenchmarkLineFormats/statsd-12                           3096838               394 ns/op             176 B/op          6 allocs/op
BenchmarkLineFormats/invalidStatsd-12                    1619024               748 ns/op             432 B/op         10 allocs/op
PASS
ok      github.com/prometheus/statsd_exporter   20.487s
```

After: 
```
$ go test -bench=BenchmarkLine.
goos: darwin
goarch: amd64
pkg: github.com/prometheus/statsd_exporter
BenchmarkLineToEventsMixed1-12            131325              8444 ns/op            4778 B/op         91 allocs/op
BenchmarkLineToEventsMixed5-12             27319             40279 ns/op           23892 B/op        455 allocs/op
BenchmarkLineToEventsMixed50-12             2986            401224 ns/op          238925 B/op       4550 allocs/op
BenchmarkLineFormats/invalidStatsd-12            1604922               745 ns/op             432 B/op         10 allocs/op
BenchmarkLineFormats/dogStatsd-12                1986829               595 ns/op             464 B/op          6 allocs/op
BenchmarkLineFormats/invalidDogStatsd-12         1713426               718 ns/op             496 B/op          8 allocs/op
BenchmarkLineFormats/signalFx-12                 1893074               636 ns/op             496 B/op          8 allocs/op
BenchmarkLineFormats/invalidSignalFx-12          1715712               712 ns/op             448 B/op         11 allocs/op
BenchmarkLineFormats/influxDb-12                 1927936               621 ns/op             464 B/op          7 allocs/op
BenchmarkLineFormats/invalidInfluxDb-12          1328978               888 ns/op             800 B/op         13 allocs/op
BenchmarkLineFormats/statsd-12                   3057933               431 ns/op             176 B/op          6 allocs/op
PASS
ok      github.com/prometheus/statsd_exporter   19.469s
```

Diff:
```
$ benchstat old.out new.out
name                             old time/op    new time/op    delta
LineToEventsMixed1-12              8.47µs ± 0%   11.37µs ± 0%   ~     (p=1.000 n=1+1)
LineToEventsMixed5-12              40.8µs ± 0%    42.7µs ± 0%   ~     (p=1.000 n=1+1)
LineToEventsMixed50-12              461µs ± 0%     400µs ± 0%   ~     (p=1.000 n=1+1)
LineFormats/influxDb-12             601ns ± 0%     604ns ± 0%   ~     (p=1.000 n=1+1)
LineFormats/invalidInfluxDb-12      918ns ± 0%     895ns ± 0%   ~     (p=1.000 n=1+1)
LineFormats/statsd-12               397ns ± 0%     414ns ± 0%   ~     (p=1.000 n=1+1)
LineFormats/invalidStatsd-12        750ns ± 0%     738ns ± 0%   ~     (p=1.000 n=1+1)
LineFormats/dogStatsd-12            630ns ± 0%     616ns ± 0%   ~     (p=1.000 n=1+1)
LineFormats/invalidDogStatsd-12     739ns ± 0%     752ns ± 0%   ~     (p=1.000 n=1+1)
LineFormats/signalFx-12             658ns ± 0%     717ns ± 0%   ~     (p=1.000 n=1+1)
LineFormats/invalidSignalFx-12      749ns ± 0%     706ns ± 0%   ~     (p=1.000 n=1+1)

name                             old alloc/op   new alloc/op   delta
LineToEventsMixed1-12              4.78kB ± 0%    4.78kB ± 0%   ~     (all equal)
LineToEventsMixed5-12              23.9kB ± 0%    23.9kB ± 0%   ~     (all equal)
LineToEventsMixed50-12              239kB ± 0%     239kB ± 0%   ~     (p=1.000 n=1+1)
LineFormats/influxDb-12              464B ± 0%      464B ± 0%   ~     (all equal)
LineFormats/invalidInfluxDb-12       800B ± 0%      800B ± 0%   ~     (all equal)
LineFormats/statsd-12                176B ± 0%      176B ± 0%   ~     (all equal)
LineFormats/invalidStatsd-12         432B ± 0%      432B ± 0%   ~     (all equal)
LineFormats/dogStatsd-12             464B ± 0%      464B ± 0%   ~     (all equal)
LineFormats/invalidDogStatsd-12      496B ± 0%      496B ± 0%   ~     (all equal)
LineFormats/signalFx-12              496B ± 0%      496B ± 0%   ~     (all equal)
LineFormats/invalidSignalFx-12       448B ± 0%      448B ± 0%   ~     (all equal)

name                             old allocs/op  new allocs/op  delta
LineToEventsMixed1-12                91.0 ± 0%      91.0 ± 0%   ~     (all equal)
LineToEventsMixed5-12                 455 ± 0%       455 ± 0%   ~     (all equal)
LineToEventsMixed50-12              4.55k ± 0%     4.55k ± 0%   ~     (all equal)
LineFormats/influxDb-12              7.00 ± 0%      7.00 ± 0%   ~     (all equal)
LineFormats/invalidInfluxDb-12       13.0 ± 0%      13.0 ± 0%   ~     (all equal)
LineFormats/statsd-12                6.00 ± 0%      6.00 ± 0%   ~     (all equal)
LineFormats/invalidStatsd-12         10.0 ± 0%      10.0 ± 0%   ~     (all equal)
LineFormats/dogStatsd-12             6.00 ± 0%      6.00 ± 0%   ~     (all equal)
LineFormats/invalidDogStatsd-12      8.00 ± 0%      8.00 ± 0%   ~     (all equal)
LineFormats/signalFx-12              8.00 ± 0%      8.00 ± 0%   ~     (all equal)
LineFormats/invalidSignalFx-12       11.0 ± 0%      11.0 ± 0%   ~     (all equal)

```