### PR TITLE
Use prometheus.Gauge interface instead of prometheus.Counter

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -79,7 +79,7 @@ func (r *Registry) StoreCounter(metricName string, hash metrics.LabelHash, label
 	r.Store(metricName, hash, labels, vec, c, metrics.CounterMetricType, ttl)
 }
 
-func (r *Registry) StoreGauge(metricName string, hash metrics.LabelHash, labels prometheus.Labels, vec *prometheus.GaugeVec, g prometheus.Counter, ttl time.Duration) {
+func (r *Registry) StoreGauge(metricName string, hash metrics.LabelHash, labels prometheus.Labels, vec *prometheus.GaugeVec, g prometheus.Gauge, ttl time.Duration) {
 	r.Store(metricName, hash, labels, vec, g, metrics.GaugeMetricType, ttl)
 }
 


### PR DESCRIPTION
Well, it doesn't change any behaviour because `prometheus.Gauge` implements `prometheus.Counter` and the conversion works also fine.

But it'd better that we fix this by using `prometheus.Gauge` for `gauge`.