### PR TITLE
Error strings shouldn't be capitalized 

### DIFF
--- a/pkg/address/address.go
+++ b/pkg/address/address.go
@@ -30,12 +30,12 @@ func IPPortFromString(addr string) (*net.IPAddr, int, error) {
 	}
 	ip, err := net.ResolveIPAddr("ip", host)
 	if err != nil {
-		return nil, 0, fmt.Errorf("Unable to resolve %s: %s", host, err)
+		return nil, 0, fmt.Errorf("unable to resolve %s: %s", host, err)
 	}
 
 	port, err := strconv.Atoi(portStr)
 	if err != nil || port < 0 || port > 65535 {
-		return nil, 0, fmt.Errorf("Bad port %s: %s", portStr, err)
+		return nil, 0, fmt.Errorf("bad port %s: %s", portStr, err)
 	}
 
 	return ip, port, nil

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -157,7 +157,7 @@ func (r *Registry) GetCounter(metricName string, labels prometheus.Labels, help 
 	}
 
 	if r.MetricConflicts(metricName, metrics.CounterMetricType) {
-		return nil, fmt.Errorf("Metric with name %s is already registered", metricName)
+		return nil, fmt.Errorf("metric with name %s is already registered", metricName)
 	}
 
 	var counterVec *prometheus.CounterVec


### PR DESCRIPTION
The error strings shouldn't be capitalized as it's considered a good practice. Because if look up the function call stack, then the function using that error message won't like if the string is capitalized.

Also, now it matches the format as the other error strings (i.e., not capitalized) present in the codebase.
