### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policies and Procedures
+
+This document outlines security procedures and general policies for the `statsd_exporter`
+project.
+
+  * [Reporting a Bug](#reporting-a-bug)
+  * [Disclosure Policy](#disclosure-policy)
+  * [Comments on this Policy](#comments-on-this-policy)
+
+## Reporting a Bug
+
+The `statsd_exporter` team and community take all security bugs in `statsd_exporter` seriously.
+Thank you for improving the security of `statsd_exporter`. We appreciate your efforts and
+responsible disclosure and will make every effort to acknowledge your
+contributions.
+
+Report security bugs by emailing the current maintainer (see MAINTAINERS.md).
+
+The current maintainer will acknowledge your email as soon as possible, and will send a
+more detailed response indicating the next steps in handling your report.
+After the initial reply to your report, the security team will
+endeavor to keep you informed of the progress towards a fix and full
+announcement, and may ask for additional information or guidance.
+
+Report security bugs in third-party modules to the person or team maintaining
+the module.
+
+## Disclosure Policy
+
+When the security team receives a security bug report, they will assign it to a
+primary handler. This person will coordinate the fix and release process,
+involving the following steps:
+
+  * Confirm the problem and determine the affected versions.
+  * Audit code to find any potential similar problems.
+  * Prepare fixes for all releases still under maintenance. These fixes will be
+    released as fast as possible.
+
+## Comments on this Policy
+
+If you have suggestions on how this process could be improved please submit a
+pull request.


### PR DESCRIPTION
Hi,

my current employer is going to use statsd_exporter in production environments. One of the requirements to an open source project to comply to strict security rules is to have a security policy adopted. Therefore I would like to propose this security policy for statsd_exporter which is based on a generic security policy recommended by GitHub.