### PR TITLE
Allow setting defaults for histogram and summary options

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ By setting this to `true`, `glob` match type will not honor the occurance of rul
 
 Setting `buckets` or `quantiles` in the defaults is deprecated in favor of `histogram_options` and `summary_options`, which will override the deprecated values.
 
-NOTE: If `summary_options` is present in a mapping config, it will override all of the `summary_options` set in the `defaults` section. 
+If `summary_options` is present in a mapping config, it will only override the fields set in the mapping. Unset fields in the mapping will take the values from the defaults. 
 
 ```yaml
 defaults:

--- a/README.md
+++ b/README.md
@@ -341,9 +341,9 @@ mappings:
         error: 0.05
       - quantile: 0.5
         error: 0.005
-    max_summary_age: 30s
-    summary_age_buckets: 3
-    stream_buffer_size: 1000
+    max_age: 30s
+    age_buckets: 3
+    buf_cap: 1000
 ```
 
 The default quantiles are 0.99, 0.9, and 0.5.
@@ -414,16 +414,32 @@ mappings:
 
 ### Global defaults
 
-One may also set defaults for the observer type, buckets or quantiles, and match type.
+One may also set defaults for the observer type, histogram options, summary options, and match type.
 These will be used by all mappings that do not define them.
 
 An option that can only be configured in `defaults` is `glob_disable_ordering`, which is `false` if omitted.
 By setting this to `true`, `glob` match type will not honor the occurance of rules in the mapping rules file and always treat `*` as lower priority than a concrete string.
 
+Setting `buckets` or `quantiles` in the defaults is deprecated in favor of `histogram_options` and `summary_options`, which will override the deprecated values. 
+
 ```yaml
 defaults:
   observer_type: histogram
-  buckets: [.005, .01, .025, .05, .1, .25, .5, 1, 2.5 ]
+  histogram_options:
+    buckets: [.005, .01, .025, .05, .1, .25, .5, 1, 2.5 ]
+  summary_options:
+    quantiles:
+      - quantile: 0.99
+        error: 0.001
+      - quantile: 0.95
+        error: 0.01
+      - quantile: 0.9
+        error: 0.05
+      - quantile: 0.5
+        error: 0.005
+    max_age: 5m
+    age_buckets: 2
+    buf_cap: 1000
   match_type: glob
   glob_disable_ordering: false
   ttl: 0 # metrics do not expire
@@ -435,7 +451,7 @@ mappings:
     provider: "$2"
     outcome: "$3"
     job: "${1}_server"
-# This will be a summary timer.
+# This will be a summary using the summary_options set in `defaults`
 - match: "other.distribution.*.*.*"
   observer_type: summary
   name: "other_distribution"

--- a/README.md
+++ b/README.md
@@ -420,7 +420,9 @@ These will be used by all mappings that do not define them.
 An option that can only be configured in `defaults` is `glob_disable_ordering`, which is `false` if omitted.
 By setting this to `true`, `glob` match type will not honor the occurance of rules in the mapping rules file and always treat `*` as lower priority than a concrete string.
 
-Setting `buckets` or `quantiles` in the defaults is deprecated in favor of `histogram_options` and `summary_options`, which will override the deprecated values. 
+Setting `buckets` or `quantiles` in the defaults is deprecated in favor of `histogram_options` and `summary_options`, which will override the deprecated values.
+
+NOTE: If `summary_options` is present in a mapping config, it will override all of the `summary_options` set in the `defaults` section. 
 
 ```yaml
 defaults:

--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -22,8 +22,9 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
-	"github.com/prometheus/statsd_exporter/pkg/mapper/fsm"
 	yaml "gopkg.in/yaml.v2"
+
+	"github.com/prometheus/statsd_exporter/pkg/mapper/fsm"
 )
 
 var (
@@ -100,7 +101,7 @@ func (m *MetricMapper) GetDefaultHistogramOptions() HistogramOptions {
 		r.Buckets = prometheus.DefBuckets
 	} else {
 		r = m.Defaults.HistogramOptions.Clone()
-		if m.Defaults.HistogramOptions != nil && len(m.Defaults.HistogramOptions.Buckets) == 0 {
+		if len(m.Defaults.HistogramOptions.Buckets) == 0 {
 			r.Buckets = prometheus.DefBuckets
 		}
 	}
@@ -115,7 +116,7 @@ func (m *MetricMapper) GetDefaultSummaryOptions() SummaryOptions {
 		r.Quantiles = defaultQuantiles
 	} else {
 		r = m.Defaults.SummaryOptions.Clone()
-		if m.Defaults.SummaryOptions != nil && len(m.Defaults.SummaryOptions.Quantiles) == 0 {
+		if len(m.Defaults.SummaryOptions.Quantiles) == 0 {
 			r.Quantiles = defaultQuantiles
 		}
 	}

--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -100,12 +100,16 @@ func (m *MetricMapper) InitFromYAMLString(fileContents string, cacheSize int, op
 		return err
 	}
 
-	if n.Defaults.Buckets == nil || len(n.Defaults.Buckets) == 0 {
-		n.Defaults.Buckets = prometheus.DefBuckets
+	if n.Defaults.HistogramOptions == nil {
+		n.Defaults.HistogramOptions = &HistogramOptions{Buckets: prometheus.DefBuckets}
+	} else if n.Defaults.HistogramOptions != nil && len(n.Defaults.HistogramOptions.Buckets) == 0 {
+		n.Defaults.HistogramOptions.Buckets = prometheus.DefBuckets
 	}
 
-	if n.Defaults.Quantiles == nil || len(n.Defaults.Quantiles) == 0 {
-		n.Defaults.Quantiles = defaultQuantiles
+	if n.Defaults.SummaryOptions == nil {
+		n.Defaults.SummaryOptions = &SummaryOptions{Quantiles: defaultQuantiles}
+	} else if n.Defaults.SummaryOptions != nil && len(n.Defaults.SummaryOptions.Quantiles) == 0 {
+		n.Defaults.SummaryOptions.Quantiles = defaultQuantiles
 	}
 
 	if n.Defaults.MatchType == MatchTypeDefault {
@@ -207,16 +211,10 @@ func (m *MetricMapper) InitFromYAMLString(fileContents string, cacheSize int, op
 				return fmt.Errorf("cannot use histogram observer and summary options at the same time")
 			}
 			if currentMapping.HistogramOptions == nil {
-				currentMapping.HistogramOptions = &HistogramOptions{}
-				if n.Defaults.HistogramOptions != nil {
-					currentMapping.HistogramOptions = n.Defaults.HistogramOptions.Clone()
-				}
+				currentMapping.HistogramOptions = n.Defaults.HistogramOptions.Clone()
 			}
 			if currentMapping.LegacyBuckets != nil && len(currentMapping.LegacyBuckets) != 0 {
 				currentMapping.HistogramOptions.Buckets = currentMapping.LegacyBuckets
-			}
-			if currentMapping.HistogramOptions.Buckets == nil || len(currentMapping.HistogramOptions.Buckets) == 0 {
-				currentMapping.HistogramOptions.Buckets = n.Defaults.Buckets
 			}
 		}
 
@@ -225,16 +223,10 @@ func (m *MetricMapper) InitFromYAMLString(fileContents string, cacheSize int, op
 				return fmt.Errorf("cannot use summary observer and histogram options at the same time")
 			}
 			if currentMapping.SummaryOptions == nil {
-				currentMapping.SummaryOptions = &SummaryOptions{}
-				if n.Defaults.SummaryOptions != nil {
-					currentMapping.SummaryOptions = n.Defaults.SummaryOptions.Clone()
-				}
+				currentMapping.SummaryOptions = n.Defaults.SummaryOptions.Clone()
 			}
 			if currentMapping.LegacyQuantiles != nil && len(currentMapping.LegacyQuantiles) != 0 {
 				currentMapping.SummaryOptions.Quantiles = currentMapping.LegacyQuantiles
-			}
-			if currentMapping.SummaryOptions.Quantiles == nil || len(currentMapping.SummaryOptions.Quantiles) == 0 {
-				currentMapping.SummaryOptions.Quantiles = n.Defaults.Quantiles
 			}
 		}
 

--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -185,6 +185,9 @@ func (m *MetricMapper) InitFromYAMLString(fileContents string, cacheSize int, op
 			}
 			if currentMapping.HistogramOptions == nil {
 				currentMapping.HistogramOptions = &HistogramOptions{}
+				if n.Defaults.HistogramOptions != nil {
+					currentMapping.HistogramOptions.Buckets = n.Defaults.HistogramOptions.Buckets
+				}
 			}
 			if currentMapping.LegacyBuckets != nil && len(currentMapping.LegacyBuckets) != 0 {
 				currentMapping.HistogramOptions.Buckets = currentMapping.LegacyBuckets
@@ -200,6 +203,12 @@ func (m *MetricMapper) InitFromYAMLString(fileContents string, cacheSize int, op
 			}
 			if currentMapping.SummaryOptions == nil {
 				currentMapping.SummaryOptions = &SummaryOptions{}
+				if n.Defaults.SummaryOptions != nil {
+					currentMapping.SummaryOptions.Quantiles = n.Defaults.SummaryOptions.Quantiles
+					currentMapping.SummaryOptions.AgeBuckets = n.Defaults.SummaryOptions.AgeBuckets
+					currentMapping.SummaryOptions.BufCap = n.Defaults.SummaryOptions.BufCap
+					currentMapping.SummaryOptions.MaxAge = n.Defaults.SummaryOptions.MaxAge
+				}
 			}
 			if currentMapping.LegacyQuantiles != nil && len(currentMapping.LegacyQuantiles) != 0 {
 				currentMapping.SummaryOptions.Quantiles = currentMapping.LegacyQuantiles

--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -55,8 +55,31 @@ type SummaryOptions struct {
 	BufCap     uint32            `yaml:"buf_cap"`
 }
 
+// Clone returns a copy of SummaryOptions
+func (s *SummaryOptions) Clone() *SummaryOptions {
+	r := SummaryOptions{
+		Quantiles: make([]metricObjective, len(s.Quantiles)),
+	}
+	copy(r.Quantiles, s.Quantiles)
+	r.MaxAge = s.MaxAge
+	r.AgeBuckets = s.AgeBuckets
+	r.BufCap = s.BufCap
+
+	return &r
+}
+
 type HistogramOptions struct {
 	Buckets []float64 `yaml:"buckets"`
+}
+
+// Clone returns a copy of HistogramOptions
+func (h *HistogramOptions) Clone() *HistogramOptions {
+	r := HistogramOptions{
+		Buckets: make([]float64, len(h.Buckets)),
+	}
+	copy(r.Buckets, h.Buckets)
+
+	return &r
 }
 
 type metricObjective struct {
@@ -186,7 +209,7 @@ func (m *MetricMapper) InitFromYAMLString(fileContents string, cacheSize int, op
 			if currentMapping.HistogramOptions == nil {
 				currentMapping.HistogramOptions = &HistogramOptions{}
 				if n.Defaults.HistogramOptions != nil {
-					currentMapping.HistogramOptions.Buckets = n.Defaults.HistogramOptions.Buckets
+					currentMapping.HistogramOptions = n.Defaults.HistogramOptions.Clone()
 				}
 			}
 			if currentMapping.LegacyBuckets != nil && len(currentMapping.LegacyBuckets) != 0 {
@@ -204,10 +227,7 @@ func (m *MetricMapper) InitFromYAMLString(fileContents string, cacheSize int, op
 			if currentMapping.SummaryOptions == nil {
 				currentMapping.SummaryOptions = &SummaryOptions{}
 				if n.Defaults.SummaryOptions != nil {
-					currentMapping.SummaryOptions.Quantiles = n.Defaults.SummaryOptions.Quantiles
-					currentMapping.SummaryOptions.AgeBuckets = n.Defaults.SummaryOptions.AgeBuckets
-					currentMapping.SummaryOptions.BufCap = n.Defaults.SummaryOptions.BufCap
-					currentMapping.SummaryOptions.MaxAge = n.Defaults.SummaryOptions.MaxAge
+					currentMapping.SummaryOptions = n.Defaults.SummaryOptions.Clone()
 				}
 			}
 			if currentMapping.LegacyQuantiles != nil && len(currentMapping.LegacyQuantiles) != 0 {

--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -96,14 +96,9 @@ var defaultQuantiles = []metricObjective{
 
 // GetDefaultHistogramOptions returns a copy of the default HistogramOptions
 func (m *MetricMapper) GetDefaultHistogramOptions() HistogramOptions {
-	r := HistogramOptions{}
-	if m.Defaults.HistogramOptions == nil {
+	r := m.Defaults.HistogramOptions.Clone()
+	if len(m.Defaults.HistogramOptions.Buckets) == 0 {
 		r.Buckets = prometheus.DefBuckets
-	} else {
-		r = m.Defaults.HistogramOptions.Clone()
-		if len(m.Defaults.HistogramOptions.Buckets) == 0 {
-			r.Buckets = prometheus.DefBuckets
-		}
 	}
 
 	return r
@@ -111,14 +106,9 @@ func (m *MetricMapper) GetDefaultHistogramOptions() HistogramOptions {
 
 // GetDefaultSummaryOptions returns a copy of the default SummaryOptions
 func (m *MetricMapper) GetDefaultSummaryOptions() SummaryOptions {
-	r := SummaryOptions{}
-	if m.Defaults.SummaryOptions == nil {
+	r := m.Defaults.SummaryOptions.Clone()
+	if len(m.Defaults.SummaryOptions.Quantiles) == 0 {
 		r.Quantiles = defaultQuantiles
-	} else {
-		r = m.Defaults.SummaryOptions.Clone()
-		if len(m.Defaults.SummaryOptions.Quantiles) == 0 {
-			r.Quantiles = defaultQuantiles
-		}
 	}
 
 	return r
@@ -131,15 +121,11 @@ func (m *MetricMapper) InitFromYAMLString(fileContents string, cacheSize int, op
 		return err
 	}
 
-	if n.Defaults.HistogramOptions == nil {
-		n.Defaults.HistogramOptions = &HistogramOptions{Buckets: prometheus.DefBuckets}
-	} else if n.Defaults.HistogramOptions != nil && len(n.Defaults.HistogramOptions.Buckets) == 0 {
+	if len(n.Defaults.HistogramOptions.Buckets) == 0 {
 		n.Defaults.HistogramOptions.Buckets = prometheus.DefBuckets
 	}
 
-	if n.Defaults.SummaryOptions == nil {
-		n.Defaults.SummaryOptions = &SummaryOptions{Quantiles: defaultQuantiles}
-	} else if n.Defaults.SummaryOptions != nil && len(n.Defaults.SummaryOptions.Quantiles) == 0 {
+	if len(n.Defaults.SummaryOptions.Quantiles) == 0 {
 		n.Defaults.SummaryOptions.Quantiles = defaultQuantiles
 	}
 

--- a/pkg/mapper/mapper_defaults.go
+++ b/pkg/mapper/mapper_defaults.go
@@ -23,6 +23,8 @@ type mapperConfigDefaults struct {
 	MatchType           MatchType         `yaml:"match_type"`
 	GlobDisableOrdering bool              `yaml:"glob_disable_ordering"`
 	Ttl                 time.Duration     `yaml:"ttl"`
+	SummaryOptions      *SummaryOptions   `yaml:"summary_options"`
+	HistogramOptions    *HistogramOptions `yaml:"histogram_options"`
 }
 
 // UnmarshalYAML is a custom unmarshal function to allow use of deprecated config keys
@@ -41,6 +43,8 @@ func (d *mapperConfigDefaults) UnmarshalYAML(unmarshal func(interface{}) error) 
 	d.MatchType = tmp.MatchType
 	d.GlobDisableOrdering = tmp.GlobDisableOrdering
 	d.Ttl = tmp.Ttl
+	d.SummaryOptions = tmp.SummaryOptions
+	d.HistogramOptions = tmp.HistogramOptions
 
 	// Use deprecated TimerType if necessary
 	if tmp.ObserverType == "" {

--- a/pkg/mapper/mapper_defaults.go
+++ b/pkg/mapper/mapper_defaults.go
@@ -23,8 +23,8 @@ type mapperConfigDefaults struct {
 	MatchType           MatchType         `yaml:"match_type"`
 	GlobDisableOrdering bool              `yaml:"glob_disable_ordering"`
 	Ttl                 time.Duration     `yaml:"ttl"`
-	SummaryOptions      *SummaryOptions   `yaml:"summary_options"`
-	HistogramOptions    *HistogramOptions `yaml:"histogram_options"`
+	SummaryOptions      SummaryOptions    `yaml:"summary_options"`
+	HistogramOptions    HistogramOptions  `yaml:"histogram_options"`
 }
 
 // UnmarshalYAML is a custom unmarshal function to allow use of deprecated config keys
@@ -50,13 +50,13 @@ func (d *mapperConfigDefaults) UnmarshalYAML(unmarshal func(interface{}) error) 
 	}
 
 	// Use deprecated quantiles if necessary
-	if tmp.SummaryOptions == nil && tmp.Quantiles != nil {
-		d.SummaryOptions = &SummaryOptions{Quantiles: tmp.Quantiles}
+	if len(tmp.SummaryOptions.Quantiles) == 0 && len(tmp.Quantiles) > 0 {
+		d.SummaryOptions = SummaryOptions{Quantiles: tmp.Quantiles}
 	}
 
 	// Use deprecated buckets if necessary
-	if tmp.HistogramOptions == nil && tmp.Buckets != nil {
-		d.HistogramOptions = &HistogramOptions{Buckets: tmp.Buckets}
+	if len(tmp.HistogramOptions.Buckets) == 0 && len(tmp.Buckets) > 0 {
+		d.HistogramOptions = HistogramOptions{Buckets: tmp.Buckets}
 	}
 
 	return nil

--- a/pkg/mapper/mapper_defaults.go
+++ b/pkg/mapper/mapper_defaults.go
@@ -18,8 +18,8 @@ import "time"
 type mapperConfigDefaults struct {
 	ObserverType        ObserverType      `yaml:"observer_type"`
 	TimerType           ObserverType      `yaml:"timer_type,omitempty"` // DEPRECATED - field only present to preserve backwards compatibility in configs. Always empty
-	Buckets             []float64         `yaml:"buckets"`
-	Quantiles           []metricObjective `yaml:"quantiles"`
+	Buckets             []float64         `yaml:"buckets"`              // DEPREECATED - field only present to preserve backwards compatibility in configs. Always empty
+	Quantiles           []metricObjective `yaml:"quantiles"`            // DEPREECATED - field only present to preserve backwards compatibility in configs. Always empty
 	MatchType           MatchType         `yaml:"match_type"`
 	GlobDisableOrdering bool              `yaml:"glob_disable_ordering"`
 	Ttl                 time.Duration     `yaml:"ttl"`
@@ -38,8 +38,6 @@ func (d *mapperConfigDefaults) UnmarshalYAML(unmarshal func(interface{}) error) 
 
 	// Copy defaults
 	d.ObserverType = tmp.ObserverType
-	d.Buckets = tmp.Buckets
-	d.Quantiles = tmp.Quantiles
 	d.MatchType = tmp.MatchType
 	d.GlobDisableOrdering = tmp.GlobDisableOrdering
 	d.Ttl = tmp.Ttl
@@ -49,6 +47,16 @@ func (d *mapperConfigDefaults) UnmarshalYAML(unmarshal func(interface{}) error) 
 	// Use deprecated TimerType if necessary
 	if tmp.ObserverType == "" {
 		d.ObserverType = tmp.TimerType
+	}
+
+	// Use deprecated quantiles if necessary
+	if tmp.SummaryOptions == nil && tmp.Quantiles != nil {
+		d.SummaryOptions = &SummaryOptions{Quantiles: tmp.Quantiles}
+	}
+
+	// Use deprecated buckets if necessary
+	if tmp.HistogramOptions == nil && tmp.Buckets != nil {
+		d.HistogramOptions = &HistogramOptions{Buckets: tmp.Buckets}
 	}
 
 	return nil

--- a/pkg/mapper/mapper_defaults.go
+++ b/pkg/mapper/mapper_defaults.go
@@ -18,8 +18,8 @@ import "time"
 type mapperConfigDefaults struct {
 	ObserverType        ObserverType      `yaml:"observer_type"`
 	TimerType           ObserverType      `yaml:"timer_type,omitempty"` // DEPRECATED - field only present to preserve backwards compatibility in configs. Always empty
-	Buckets             []float64         `yaml:"buckets"`              // DEPREECATED - field only present to preserve backwards compatibility in configs. Always empty
-	Quantiles           []metricObjective `yaml:"quantiles"`            // DEPREECATED - field only present to preserve backwards compatibility in configs. Always empty
+	Buckets             []float64         `yaml:"buckets"`              // DEPRECATED - field only present to preserve backwards compatibility in configs. Always empty
+	Quantiles           []metricObjective `yaml:"quantiles"`            // DEPRECATED - field only present to preserve backwards compatibility in configs. Always empty
 	MatchType           MatchType         `yaml:"match_type"`
 	GlobDisableOrdering bool              `yaml:"glob_disable_ordering"`
 	Ttl                 time.Duration     `yaml:"ttl"`

--- a/pkg/mapper/mapper_test.go
+++ b/pkg/mapper/mapper_test.go
@@ -39,11 +39,9 @@ func TestMetricMapperYAML(t *testing.T) {
 		configBad bool
 		mappings  mappings
 	}{
-		// Empty config.
 		{
 			testName: "Empty config",
 		},
-		// Config with several mapping definitions.
 		{
 			testName: "Config with several mapping definitions",
 			config: `---
@@ -158,7 +156,6 @@ mappings:
 				},
 			},
 		},
-		// Config with backtracking
 		{
 			testName: "Config with backtracking",
 			config: `
@@ -239,7 +236,6 @@ mappings:
 				},
 			},
 		},
-		//Config with super sets, disables ordering
 		{
 			testName: "Config with super sets, disables ordering",
 			config: `
@@ -276,7 +272,6 @@ mappings:
 				},
 			},
 		},
-		//Config with super sets, keeps ordering
 		{
 			testName: "Config with super sets, keeps ordering",
 			config: `
@@ -302,7 +297,6 @@ mappings:
 				},
 			},
 		},
-		// Config with bad regex reference.
 		{
 			testName: "Config with bad regex reference",
 			config: `---
@@ -322,7 +316,6 @@ mappings:
 				},
 			},
 		},
-		// Config with good regex reference.
 		{
 			testName: "Config with good regex reference",
 			config: `
@@ -342,7 +335,6 @@ mappings:
 				},
 			},
 		},
-		// Config with bad metric line.
 		{
 			testName: "Config with bad metric line",
 			config: `---
@@ -353,7 +345,6 @@ mappings:
   `,
 			configBad: true,
 		},
-		// Config with dynamic metric name.
 		{
 			testName: "Config with dynamic metric name",
 			config: `---
@@ -384,7 +375,6 @@ mappings:
 				},
 			},
 		},
-		// Config with bad metric name.
 		{
 			testName: "Config with bad metric name",
 			config: `---
@@ -395,7 +385,6 @@ mappings:
   `,
 			configBad: true,
 		},
-		// Config with no metric name.
 		{
 			testName: "Config with no metric name",
 			config: `---
@@ -406,13 +395,11 @@ mappings:
   `,
 			configBad: true,
 		},
-		// Config with no mappings.
 		{
 			testName: "Config with no mappings",
 			config:   ``,
 			mappings: mappings{},
 		},
-		// Config without a trailing newline.
 		{
 			testName: "Config without a trailing newline",
 			config: `mappings:
@@ -430,7 +417,6 @@ mappings:
 				},
 			},
 		},
-		// Config with an improperly escaped *.
 		{
 			testName: "Config with an improperly escaped *",
 			config: `
@@ -441,7 +427,6 @@ mappings:
     label: "${1}_foo"`,
 			configBad: true,
 		},
-		// Config with a properly escaped *.
 		{
 			testName: "Config with a properly escaped *",
 			config: `
@@ -460,7 +445,6 @@ mappings:
 				},
 			},
 		},
-		// Config with good observer type.
 		{
 			testName: "Config with good observer type",
 			config: `---
@@ -487,7 +471,6 @@ mappings:
 				},
 			},
 		},
-		// Config with good observer type and unused timer type
 		{
 			testName: "Config with good observer type and unused timer type",
 			config: `---
@@ -537,7 +520,6 @@ mappings:
 				},
 			},
 		},
-		// Config with good deprecated timer type
 		{
 			testName: "Config with good deprecated timer type",
 			config: `---
@@ -560,7 +542,6 @@ mappings:
 				},
 			},
 		},
-		// Config with bad observer type.
 		{
 			testName: "Config with bad observer type",
 			config: `---
@@ -572,7 +553,6 @@ mappings:
     `,
 			configBad: true,
 		},
-		// Config with bad deprecated timer type.
 		{
 			testName: "Config with bad deprecated timer type",
 			config: `---
@@ -584,7 +564,6 @@ mappings:
     `,
 			configBad: true,
 		},
-		// New style quantiles
 		{
 			testName: "New style quantiles",
 			config: `---
@@ -612,7 +591,6 @@ mappings:
 				},
 			},
 		},
-		// Config with summary options.
 		{
 			testName: "Config with summary options",
 			config: `---
@@ -646,7 +624,6 @@ mappings:
 				},
 			},
 		},
-		// Config with default summary options.
 		{
 			testName: "Config with default summary options",
 			config: `---
@@ -681,7 +658,6 @@ mappings:
 				},
 			},
 		},
-		// Config that overrides default summary options.
 		{
 			testName: "Config that overrides default summary options",
 			config: `---
@@ -725,7 +701,65 @@ mappings:
 				},
 			},
 		},
-		// Config with histogram options.
+				{
+			testName: "Config that overrides default summary options and a default options mapping",
+			config: `---
+defaults:
+ summary_options:
+   quantiles:
+     - quantile: 0.9
+       error: 0.1
+     - quantile: 0.99
+       error: 0.01
+   max_age: 15m
+   age_buckets: 3
+   buf_cap: 100
+mappings:
+- match: test.*.*
+  observer_type: summary
+  name: "foo"
+  labels: {}
+  summary_options:
+    quantiles:
+     - quantile: 0.42
+       error: 0.04
+     - quantile: 0.7
+       error: 0.002
+    max_age: 5m
+    age_buckets: 2
+    buf_cap: 1000
+- match: test_default.*.*
+  observer_type: summary
+  name: "foo_default"
+  labels: {}
+`,
+			mappings: mappings{
+				{
+					statsdMetric: "test.*.*",
+					name:         "foo",
+					labels:       map[string]string{},
+					quantiles: []metricObjective{
+						{Quantile: 0.42, Error: 0.04},
+						{Quantile: 0.7, Error: 0.002},
+					},
+					maxAge:     5 * time.Minute,
+					ageBuckets: 2,
+					bufCap:     1000,
+				},
+				{
+					statsdMetric: "test_default.*.*",
+					name:         "foo_default",
+					labels:       map[string]string{},
+					quantiles: []metricObjective{
+						{Quantile: 0.9, Error: 0.1},
+						{Quantile: 0.99, Error: 0.01},
+					},
+					maxAge:     15 * time.Minute,
+					ageBuckets: 3,
+					bufCap:     100,
+				},
+			},
+		},
 		{
 			testName: "Config with histogram options",
 			config: `---
@@ -746,7 +780,6 @@ mappings:
 				},
 			},
 		},
-		// Config with default histogram options.
 		{
 			testName: "Config with default histogram options",
 			config: `---
@@ -768,7 +801,6 @@ mappings:
 				},
 			},
 		},
-		// Config that overrides default histogram configuration.
 		{
 			testName: "Config that overrides default histogram configuration",
 			config: `---
@@ -792,8 +824,39 @@ mappings:
 				},
 			},
 		},
-
-		// Duplicate quantiles are bad
+		{
+			testName: "Config that overrides default histogram configuration and a default options mapping",
+			config: `---
+defaults:
+  histogram_options:
+    buckets: [0.2, 2, 20, 200]
+mappings:
+- match: test.*.*
+  observer_type: histogram
+  name: "foo"
+  labels: {}
+  histogram_options:
+    buckets: [0.1, 1, 10, 100, 1000]
+- match: test_default.*.*
+  observer_type: histogram
+  name: "foo_default"
+  labels: {}
+`,
+			mappings: mappings{
+				{
+					statsdMetric: "test.*.*",
+					name:         "foo",
+					labels:       map[string]string{},
+					buckets:      []float64{0.1, 1, 10, 100, 1000},
+				},
+				{
+					statsdMetric: "test_default.*.*",
+					name:         "foo_default",
+					labels:       map[string]string{},
+					buckets:      []float64{0.2, 2, 20, 200},
+				},
+			},
+		},
 		{
 			testName: "Duplicate quantiles are bad",
 			config: `---
@@ -812,7 +875,6 @@ mappings:
   `,
 			configBad: true,
 		},
-		// Config with good metric type.
 		{
 			testName: "Config with good metric type",
 			config: `---
@@ -823,7 +885,6 @@ mappings:
   labels: {}
     `,
 		},
-		// Config with good metric type observer.
 		{
 			testName: "Config with good metric type observer",
 			config: `---
@@ -834,7 +895,6 @@ mappings:
   labels: {}
     `,
 		},
-		// Config with good metric type timer.
 		{
 			testName: "Config with good metric type timer",
 			config: `---
@@ -845,7 +905,6 @@ mappings:
   labels: {}
     `,
 		},
-		// Config with bad metric type matcher.
 		{
 			testName: "Config with bad metric type matcher",
 			config: `---
@@ -857,7 +916,6 @@ mappings:
     `,
 			configBad: true,
 		},
-		// Config with multiple explicit metric types
 		{
 			testName: "Config with multiple explicit metric types",
 			config: `---
@@ -882,7 +940,6 @@ mappings:
 				},
 			},
 		},
-		//Config with uncompilable regex.
 		{
 			testName: "Config with uncompilable regex",
 			config: `---
@@ -894,7 +951,6 @@ mappings:
     `,
 			configBad: true,
 		},
-		//Config with non-matched metric.
 		{
 			testName: "Config with non-matched metric",
 			config: `---
@@ -913,7 +969,6 @@ mappings:
 				},
 			},
 		},
-		//Config with no name.
 		{
 			testName: "Config with no name",
 			config: `---
@@ -949,7 +1004,6 @@ mappings:
 				},
 			},
 		},
-		// Example from the README.
 		{
 			testName: "Example from the README",
 			config: `
@@ -995,7 +1049,6 @@ mappings:
 				},
 			},
 		},
-		// Config that drops all.
 		{
 			testName: "Config that drops all",
 			config: `mappings:
@@ -1012,7 +1065,6 @@ mappings:
 				},
 			},
 		},
-		// Config that has a catch-all to drop all.
 		{
 			testName: "Config that has a catch-all to drop all",
 			config: `mappings:
@@ -1037,7 +1089,6 @@ mappings:
 				},
 			},
 		},
-		// Config that has a ttl.
 		{
 			testName: "Config that has a ttl",
 			config: `mappings:
@@ -1060,7 +1111,6 @@ mappings:
 				},
 			},
 		},
-		// Config that has a default ttl.
 		{
 			testName: "Config that has a default ttl",
 			config: `defaults:
@@ -1084,7 +1134,6 @@ mappings:
 				},
 			},
 		},
-		// Config that override a default ttl.
 		{
 			testName: "Config that override a default ttl",
 			config: `defaults:
@@ -1200,7 +1249,6 @@ func TestAction(t *testing.T) {
 		expectedAction ActionType
 	}{
 		{
-			// no action set
 			testName: "no action set",
 			config: `---
 mappings:
@@ -1211,7 +1259,6 @@ mappings:
 			expectedAction: ActionTypeMap,
 		},
 		{
-			// map action set
 			testName: "map action set",
 			config: `---
 mappings:
@@ -1223,7 +1270,6 @@ mappings:
 			expectedAction: ActionTypeMap,
 		},
 		{
-			// drop action set
 			testName: "drop action set",
 			config: `---
 mappings:
@@ -1235,7 +1281,6 @@ mappings:
 			expectedAction: ActionTypeDrop,
 		},
 		{
-			// invalid action set
 			testName: "invalid action set",
 			config: `---
 mappings:
@@ -1247,7 +1292,6 @@ mappings:
 			expectedAction: ActionTypeDrop,
 		},
 		{
-			// valid yaml example
 			testName: "valid yaml example",
 			config: `---
 mappings:
@@ -1261,7 +1305,6 @@ mappings:
 			expectedAction: ActionTypeMap,
 		},
 		{
-			// invalid yaml example
 			testName: "invalid yaml example",
 			config: `---
 mappings:

--- a/pkg/mapper/mapper_test.go
+++ b/pkg/mapper/mapper_test.go
@@ -34,14 +34,18 @@ type mappings []struct {
 
 func TestMetricMapperYAML(t *testing.T) {
 	scenarios := []struct {
+		testName  string
 		config    string
 		configBad bool
 		mappings  mappings
 	}{
 		// Empty config.
-		{},
+		{
+			testName: "Empty config",
+		},
 		// Config with several mapping definitions.
 		{
+			testName: "Config with several mapping definitions",
 			config: `---
 mappings:
 - match: test.dispatcher.*.*.*
@@ -154,8 +158,9 @@ mappings:
 				},
 			},
 		},
-		//Config with backtracking
+		// Config with backtracking
 		{
+			testName: "Config with backtracking",
 			config: `
 defaults:
   glob_disable_ordering: true
@@ -199,6 +204,7 @@ mappings:
 		// This test case makes sure the captures in the non-matched later rule
 		// doesn't affect the captures in the first matched rule.
 		{
+			testName: "Config with backtracking, the non-matched rule has star(s)",
 			config: `
 defaults:
   glob_disable_ordering: false
@@ -235,6 +241,7 @@ mappings:
 		},
 		//Config with super sets, disables ordering
 		{
+			testName: "Config with super sets, disables ordering",
 			config: `
 defaults:
   glob_disable_ordering: true
@@ -271,6 +278,7 @@ mappings:
 		},
 		//Config with super sets, keeps ordering
 		{
+			testName: "Config with super sets, keeps ordering",
 			config: `
 defaults:
   glob_disable_ordering: false
@@ -296,6 +304,7 @@ mappings:
 		},
 		// Config with bad regex reference.
 		{
+			testName: "Config with bad regex reference",
 			config: `---
 mappings:
 - match: test.*
@@ -315,6 +324,7 @@ mappings:
 		},
 		// Config with good regex reference.
 		{
+			testName: "Config with good regex reference",
 			config: `
 mappings:
 - match: test.*
@@ -334,6 +344,7 @@ mappings:
 		},
 		// Config with bad metric line.
 		{
+			testName: "Config with bad metric line",
 			config: `---
 mappings:
 - match: bad--metric-line.*.*
@@ -344,6 +355,7 @@ mappings:
 		},
 		// Config with dynamic metric name.
 		{
+			testName: "Config with dynamic metric name",
 			config: `---
 mappings:
 - match: test1.*.*
@@ -374,6 +386,7 @@ mappings:
 		},
 		// Config with bad metric name.
 		{
+			testName: "Config with bad metric name",
 			config: `---
 mappings:
 - match: test.*.*
@@ -384,6 +397,7 @@ mappings:
 		},
 		// Config with no metric name.
 		{
+			testName: "Config with no metric name",
 			config: `---
 mappings:
 - match: test.*.*
@@ -394,11 +408,13 @@ mappings:
 		},
 		// Config with no mappings.
 		{
+			testName: "Config with no mappings",
 			config:   ``,
 			mappings: mappings{},
 		},
 		// Config without a trailing newline.
 		{
+			testName: "Config without a trailing newline",
 			config: `mappings:
 - match: test.*
   name: "name"
@@ -416,6 +432,7 @@ mappings:
 		},
 		// Config with an improperly escaped *.
 		{
+			testName: "Config with an improperly escaped *",
 			config: `
 mappings:
 - match: *.test.*
@@ -426,6 +443,7 @@ mappings:
 		},
 		// Config with a properly escaped *.
 		{
+			testName: "Config with a properly escaped *",
 			config: `
 mappings:
 - match: "*.test.*"
@@ -444,6 +462,7 @@ mappings:
 		},
 		// Config with good observer type.
 		{
+			testName: "Config with good observer type",
 			config: `---
 mappings:
 - match: test.*.*
@@ -470,6 +489,7 @@ mappings:
 		},
 		// Config with good observer type and unused timer type
 		{
+			testName: "Config with good observer type and unused timer type",
 			config: `---
 mappings:
 - match: test.*.*
@@ -496,6 +516,7 @@ mappings:
 			},
 		},
 		{
+			testName: "Config with good observertype and no defaults",
 			config: `---
 mappings:
 - match: test1.*.*
@@ -518,6 +539,7 @@ mappings:
 		},
 		// Config with good deprecated timer type
 		{
+			testName: "Config with good deprecated timer type",
 			config: `---
 mappings:
 - match: test1.*.*
@@ -540,6 +562,7 @@ mappings:
 		},
 		// Config with bad observer type.
 		{
+			testName: "Config with bad observer type",
 			config: `---
 mappings:
 - match: test.*.*
@@ -551,6 +574,7 @@ mappings:
 		},
 		// Config with bad deprecated timer type.
 		{
+			testName: "Config with bad deprecated timer type",
 			config: `---
 mappings:
 - match: test.*.*
@@ -560,8 +584,9 @@ mappings:
     `,
 			configBad: true,
 		},
-		// new style quantiles
+		// New style quantiles
 		{
+			testName: "New style quantiles",
 			config: `---
 mappings:
 - match: test.*.*
@@ -587,8 +612,9 @@ mappings:
 				},
 			},
 		},
-		// Config with summary configuration.
+		// Config with summary options.
 		{
+			testName: "Config with summary options",
 			config: `---
 mappings:
 - match: test.*.*
@@ -620,8 +646,9 @@ mappings:
 				},
 			},
 		},
-		// Config with default summary configuration.
+		// Config with default summary options.
 		{
+			testName: "Config with default summary options",
 			config: `---
 defaults:
  summary_options:
@@ -654,8 +681,9 @@ mappings:
 				},
 			},
 		},
-				// Config that overrides default summary configuration.
+		// Config that overrides default summary options.
 		{
+			testName: "Config that overrides default summary options",
 			config: `---
 defaults:
  summary_options:
@@ -697,8 +725,9 @@ mappings:
 				},
 			},
 		},
-		// Config with histogram configuration.
+		// Config with histogram options.
 		{
+			testName: "Config with histogram options",
 			config: `---
 mappings:
 - match: test.*.*
@@ -717,8 +746,9 @@ mappings:
 				},
 			},
 		},
-		// Config with default histogram configuration.
+		// Config with default histogram options.
 		{
+			testName: "Config with default histogram options",
 			config: `---
 defaults:
   histogram_options:
@@ -738,8 +768,9 @@ mappings:
 				},
 			},
 		},
-				// Config that overrides default histogram configuration.
+		// Config that overrides default histogram configuration.
 		{
+			testName: "Config that overrides default histogram configuration",
 			config: `---
 defaults:
   histogram_options:
@@ -762,8 +793,9 @@ mappings:
 			},
 		},
 
-		// duplicate quantiles are bad
+		// Duplicate quantiles are bad
 		{
+			testName: "Duplicate quantiles are bad",
 			config: `---
 mappings:
 - match: test.*.*
@@ -782,6 +814,7 @@ mappings:
 		},
 		// Config with good metric type.
 		{
+			testName: "Config with good metric type",
 			config: `---
 mappings:
 - match: test.*.*
@@ -792,6 +825,7 @@ mappings:
 		},
 		// Config with good metric type observer.
 		{
+			testName: "Config with good metric type observer",
 			config: `---
 mappings:
 - match: test.*.*
@@ -802,6 +836,7 @@ mappings:
 		},
 		// Config with good metric type timer.
 		{
+			testName: "Config with good metric type timer",
 			config: `---
 mappings:
 - match: test.*.*
@@ -812,6 +847,7 @@ mappings:
 		},
 		// Config with bad metric type matcher.
 		{
+			testName: "Config with bad metric type matcher",
 			config: `---
 mappings:
 - match: test.*.*
@@ -823,6 +859,7 @@ mappings:
 		},
 		// Config with multiple explicit metric types
 		{
+			testName: "Config with multiple explicit metric types",
 			config: `---
 mappings:
 - match: test.foo.*
@@ -847,6 +884,7 @@ mappings:
 		},
 		//Config with uncompilable regex.
 		{
+			testName: "Config with uncompilable regex",
 			config: `---
 mappings:
 - match: "*\\.foo"
@@ -858,6 +896,7 @@ mappings:
 		},
 		//Config with non-matched metric.
 		{
+			testName: "Config with non-matched metric",
 			config: `---
 mappings:
 - match: foo.*.*
@@ -876,6 +915,7 @@ mappings:
 		},
 		//Config with no name.
 		{
+			testName: "Config with no name",
 			config: `---
 mappings:
 - match: *\.foo
@@ -886,6 +926,7 @@ mappings:
 			configBad: true,
 		},
 		{
+			testName: "Config with labels from glob",
 			config: `---
 mappings:
 - match: p.*.*.c.*
@@ -910,6 +951,7 @@ mappings:
 		},
 		// Example from the README.
 		{
+			testName: "Example from the README",
 			config: `
 mappings:
 - match: test.dispatcher.*.*.*
@@ -955,6 +997,7 @@ mappings:
 		},
 		// Config that drops all.
 		{
+			testName: "Config that drops all",
 			config: `mappings:
 - match: .
   match_type: regex
@@ -971,6 +1014,7 @@ mappings:
 		},
 		// Config that has a catch-all to drop all.
 		{
+			testName: "Config that has a catch-all to drop all",
 			config: `mappings:
 - match: web.*
   name: "web"
@@ -995,6 +1039,7 @@ mappings:
 		},
 		// Config that has a ttl.
 		{
+			testName: "Config that has a ttl",
 			config: `mappings:
 - match: web.*
   name: "web"
@@ -1017,6 +1062,7 @@ mappings:
 		},
 		// Config that has a default ttl.
 		{
+			testName: "Config that has a default ttl",
 			config: `defaults:
   ttl: 1m2s
 mappings:
@@ -1040,6 +1086,7 @@ mappings:
 		},
 		// Config that override a default ttl.
 		{
+			testName: "Config that override a default ttl",
 			config: `defaults:
   ttl: 1m2s
 mappings:
@@ -1066,88 +1113,95 @@ mappings:
 
 	mapper := MetricMapper{}
 	for i, scenario := range scenarios {
-		err := mapper.InitFromYAMLString(scenario.config, 1000)
-		if err != nil && !scenario.configBad {
-			t.Fatalf("%d. Config load error: %s %s", i, scenario.config, err)
+		if scenario.testName == "" {
+			t.Fatalf("Missing testName in scenario %+v", scenario)
 		}
-		if err == nil && scenario.configBad {
-			t.Fatalf("%d. Expected bad config, but loaded ok: %s", i, scenario.config)
-		}
-
-		for metric, mapping := range scenario.mappings {
-			// exporter will call mapper.GetMapping with valid MetricType
-			// so we also pass a sane MetricType in testing if it's not specified
-			mapType := mapping.metricType
-			if mapType == "" {
-				mapType = MetricTypeCounter
+		t.Run(scenario.testName, func(t *testing.T) {
+			err := mapper.InitFromYAMLString(scenario.config, 1000)
+			if err != nil && !scenario.configBad {
+				t.Fatalf("%d. Config load error: %s %s", i, scenario.config, err)
 			}
-			m, labels, present := mapper.GetMapping(mapping.statsdMetric, mapType)
-			if present && mapping.name != "" && m.Name != mapping.name {
-				t.Fatalf("%d.%q: Expected name %v, got %v", i, metric, m.Name, mapping.name)
-			}
-			if mapping.notPresent && present {
-				t.Fatalf("%d.%q: Expected metric to not be present", i, metric)
-			}
-			if len(labels) != len(mapping.labels) {
-				t.Fatalf("%d.%q: Expected %d labels, got %d", i, metric, len(mapping.labels), len(labels))
-			}
-			for label, value := range labels {
-				if mapping.labels[label] != value {
-					t.Fatalf("%d.%q: Expected labels %v, got %v", i, metric, mapping, labels)
-				}
-			}
-			if mapping.ttl > 0 && mapping.ttl != m.Ttl {
-				t.Fatalf("%d.%q: Expected ttl of %s, got %s", i, metric, mapping.ttl.String(), m.Ttl.String())
-			}
-			if mapping.metricType != "" && mapType != m.MatchMetricType {
-				t.Fatalf("%d.%q: Expected match metric of %s, got %s", i, metric, mapType, m.MatchMetricType)
+			if err == nil && scenario.configBad {
+				t.Fatalf("%d. Expected bad config, but loaded ok: %s", i, scenario.config)
 			}
 
-			if len(mapping.buckets) != 0 {
-				if len(mapping.buckets) != len(m.HistogramOptions.Buckets) {
-					t.Fatalf("%d.%q: Expected %d buckets, got %d", i, metric, len(mapping.buckets), len(m.HistogramOptions.Buckets))
+			for metric, mapping := range scenario.mappings {
+				// exporter will call mapper.GetMapping with valid MetricType
+				// so we also pass a sane MetricType in testing if it's not specified
+				mapType := mapping.metricType
+				if mapType == "" {
+					mapType = MetricTypeCounter
 				}
-				for i, bucket := range mapping.buckets {
-					if bucket != m.HistogramOptions.Buckets[i] {
-						t.Fatalf("%d.%q: Expected bucket %v, got %v", i, metric, m.HistogramOptions.Buckets[i], bucket)
+				m, labels, present := mapper.GetMapping(mapping.statsdMetric, mapType)
+				if present && mapping.name != "" && m.Name != mapping.name {
+					t.Fatalf("%d.%q: Expected name %v, got %v", i, metric, m.Name, mapping.name)
+				}
+				if mapping.notPresent && present {
+					t.Fatalf("%d.%q: Expected metric to not be present", i, metric)
+				}
+				if len(labels) != len(mapping.labels) {
+					t.Fatalf("%d.%q: Expected %d labels, got %d", i, metric, len(mapping.labels), len(labels))
+				}
+				for label, value := range labels {
+					if mapping.labels[label] != value {
+						t.Fatalf("%d.%q: Expected labels %v, got %v", i, metric, mapping, labels)
 					}
 				}
-			}
+				if mapping.ttl > 0 && mapping.ttl != m.Ttl {
+					t.Fatalf("%d.%q: Expected ttl of %s, got %s", i, metric, mapping.ttl.String(), m.Ttl.String())
+				}
+				if mapping.metricType != "" && mapType != m.MatchMetricType {
+					t.Fatalf("%d.%q: Expected match metric of %s, got %s", i, metric, mapType, m.MatchMetricType)
+				}
 
-			if len(mapping.quantiles) != 0 {
-				if len(mapping.quantiles) != len(m.SummaryOptions.Quantiles) {
-					t.Fatalf("%d.%q: Expected %d quantiles, got %d", i, metric, len(mapping.quantiles), len(m.SummaryOptions.Quantiles))
-				}
-				for i, quantile := range mapping.quantiles {
-					if quantile.Quantile != m.SummaryOptions.Quantiles[i].Quantile {
-						t.Fatalf("%d.%q: Expected quantile %v, got %v", i, metric, m.SummaryOptions.Quantiles[i].Quantile, quantile.Quantile)
+				if len(mapping.buckets) != 0 {
+					if len(mapping.buckets) != len(m.HistogramOptions.Buckets) {
+						t.Fatalf("%d.%q: Expected %d buckets, got %d", i, metric, len(mapping.buckets), len(m.HistogramOptions.Buckets))
 					}
-					if quantile.Error != m.SummaryOptions.Quantiles[i].Error {
-						t.Fatalf("%d.%q: Expected Error margin %v, got %v", i, metric, m.SummaryOptions.Quantiles[i].Error, quantile.Error)
+					for i, bucket := range mapping.buckets {
+						if bucket != m.HistogramOptions.Buckets[i] {
+							t.Fatalf("%d.%q: Expected bucket %v, got %v", i, metric, m.HistogramOptions.Buckets[i], bucket)
+						}
 					}
 				}
+
+				if len(mapping.quantiles) != 0 {
+					if len(mapping.quantiles) != len(m.SummaryOptions.Quantiles) {
+						t.Fatalf("%d.%q: Expected %d quantiles, got %d", i, metric, len(mapping.quantiles), len(m.SummaryOptions.Quantiles))
+					}
+					for i, quantile := range mapping.quantiles {
+						if quantile.Quantile != m.SummaryOptions.Quantiles[i].Quantile {
+							t.Fatalf("%d.%q: Expected quantile %v, got %v", i, metric, m.SummaryOptions.Quantiles[i].Quantile, quantile.Quantile)
+						}
+						if quantile.Error != m.SummaryOptions.Quantiles[i].Error {
+							t.Fatalf("%d.%q: Expected Error margin %v, got %v", i, metric, m.SummaryOptions.Quantiles[i].Error, quantile.Error)
+						}
+					}
+				}
+				if mapping.maxAge != 0 && mapping.maxAge != m.SummaryOptions.MaxAge {
+					t.Fatalf("%d.%q: Expected max age %v, got %v", i, metric, mapping.maxAge, m.SummaryOptions.MaxAge)
+				}
+				if mapping.ageBuckets != 0 && mapping.ageBuckets != m.SummaryOptions.AgeBuckets {
+					t.Fatalf("%d.%q: Expected max age %v, got %v", i, metric, mapping.ageBuckets, m.SummaryOptions.AgeBuckets)
+				}
+				if mapping.bufCap != 0 && mapping.bufCap != m.SummaryOptions.BufCap {
+					t.Fatalf("%d.%q: Expected max age %v, got %v", i, metric, mapping.bufCap, m.SummaryOptions.BufCap)
+				}
 			}
-			if mapping.maxAge != 0 && mapping.maxAge != m.SummaryOptions.MaxAge {
-				t.Fatalf("%d.%q: Expected max age %v, got %v", i, metric, mapping.maxAge, m.SummaryOptions.MaxAge)
-			}
-			if mapping.ageBuckets != 0 && mapping.ageBuckets != m.SummaryOptions.AgeBuckets {
-				t.Fatalf("%d.%q: Expected max age %v, got %v", i, metric, mapping.ageBuckets, m.SummaryOptions.AgeBuckets)
-			}
-			if mapping.bufCap != 0 && mapping.bufCap != m.SummaryOptions.BufCap {
-				t.Fatalf("%d.%q: Expected max age %v, got %v", i, metric, mapping.bufCap, m.SummaryOptions.BufCap)
-			}
-		}
+		})
 	}
 }
 
 func TestAction(t *testing.T) {
 	scenarios := []struct {
+		testName       string
 		config         string
 		configBad      bool
 		expectedAction ActionType
 	}{
 		{
 			// no action set
+			testName: "no action set",
 			config: `---
 mappings:
 - match: test.*.*
@@ -1158,6 +1212,7 @@ mappings:
 		},
 		{
 			// map action set
+			testName: "map action set",
 			config: `---
 mappings:
 - match: test.*.*
@@ -1169,6 +1224,7 @@ mappings:
 		},
 		{
 			// drop action set
+			testName: "drop action set",
 			config: `---
 mappings:
 - match: test.*.*
@@ -1180,6 +1236,7 @@ mappings:
 		},
 		{
 			// invalid action set
+			testName: "invalid action set",
 			config: `---
 mappings:
 - match: test.*.*
@@ -1191,6 +1248,7 @@ mappings:
 		},
 		{
 			// valid yaml example
+			testName: "valid yaml example",
 			config: `---
 mappings:
 - match: "test\\.(\\w+)\\.(\\w+)\\.counter"
@@ -1204,6 +1262,7 @@ mappings:
 		},
 		{
 			// invalid yaml example
+			testName: "invalid yaml example",
 			config: `---
 mappings:
 - match: "test\.(\w+)\.(\w+)\.counter"
@@ -1217,21 +1276,26 @@ mappings:
 	}
 
 	for i, scenario := range scenarios {
-		mapper := MetricMapper{}
-		err := mapper.InitFromYAMLString(scenario.config, 0)
-		if err != nil && !scenario.configBad {
-			t.Fatalf("%d. Config load error: %s %s", i, scenario.config, err)
+		if scenario.testName == "" {
+			t.Fatalf("Missing testName in scenario %+v", scenario)
 		}
-		if err == nil && scenario.configBad {
-			t.Fatalf("%d. Expected bad config, but loaded ok: %s", i, scenario.config)
-		}
-
-		if !scenario.configBad {
-			a := mapper.Mappings[0].Action
-			if scenario.expectedAction != a {
-				t.Fatalf("%d: Expected action %v, got %v", i, scenario.expectedAction, a)
+		t.Run(scenario.testName, func(t *testing.T) {
+			mapper := MetricMapper{}
+			err := mapper.InitFromYAMLString(scenario.config, 0)
+			if err != nil && !scenario.configBad {
+				t.Fatalf("%d. Config load error: %s %s", i, scenario.config, err)
 			}
-		}
+			if err == nil && scenario.configBad {
+				t.Fatalf("%d. Expected bad config, but loaded ok: %s", i, scenario.config)
+			}
+
+			if !scenario.configBad {
+				a := mapper.Mappings[0].Action
+				if scenario.expectedAction != a {
+					t.Fatalf("%d: Expected action %v, got %v", i, scenario.expectedAction, a)
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -251,8 +251,8 @@ func (r *Registry) GetHistogram(metricName string, labels prometheus.Labels, hel
 		metricsCount.WithLabelValues("histogram").Inc()
 		histogramOptions := r.Mapper.GetDefaultHistogramOptions()
 
-		if mapping != nil {
-			if mapping.HistogramOptions != nil && len(mapping.HistogramOptions.Buckets) > 0 {
+		if mapping != nil && mapping.HistogramOptions != nil {
+			if len(mapping.HistogramOptions.Buckets) > 0 {
 				histogramOptions.Buckets = mapping.HistogramOptions.Buckets
 			}
 		}
@@ -301,18 +301,17 @@ func (r *Registry) GetSummary(metricName string, labels prometheus.Labels, help 
 		metricsCount.WithLabelValues("summary").Inc()
 		summaryOptions := r.Mapper.GetDefaultSummaryOptions()
 		if mapping != nil && mapping.SummaryOptions != nil {
-			tmp := mapping.SummaryOptions.Clone()
-			if len(tmp.Quantiles) > 0 {
-				summaryOptions.Quantiles = tmp.Quantiles
+			if len(mapping.SummaryOptions.Quantiles) > 0 {
+				summaryOptions.Quantiles = mapping.SummaryOptions.Quantiles
 			}
-			if tmp.BufCap != 0 {
-				summaryOptions.BufCap = tmp.BufCap
+			if mapping.SummaryOptions.BufCap != 0 {
+				summaryOptions.BufCap = mapping.SummaryOptions.BufCap
 			}
-			if tmp.AgeBuckets != 0 {
-				summaryOptions.AgeBuckets = tmp.AgeBuckets
+			if mapping.SummaryOptions.AgeBuckets != 0 {
+				summaryOptions.AgeBuckets = mapping.SummaryOptions.AgeBuckets
 			}
-			if tmp.MaxAge != 0 {
-				summaryOptions.MaxAge = tmp.MaxAge
+			if mapping.SummaryOptions.MaxAge != 0 {
+				summaryOptions.MaxAge = mapping.SummaryOptions.MaxAge
 			}
 		}
 

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -248,7 +248,7 @@ func (r *Registry) GetHistogram(metricName string, labels prometheus.Labels, hel
 	var histogramVec *prometheus.HistogramVec
 	if vh == nil {
 		metricsCount.WithLabelValues("histogram").Inc()
-		buckets := r.Mapper.Defaults.Buckets
+		buckets := r.Mapper.Defaults.HistogramOptions.Buckets
 		if mapping.HistogramOptions != nil && len(mapping.HistogramOptions.Buckets) > 0 {
 			buckets = mapping.HistogramOptions.Buckets
 		}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
+
 	"github.com/prometheus/statsd_exporter/pkg/clock"
 	"github.com/prometheus/statsd_exporter/pkg/mapper"
 	"github.com/prometheus/statsd_exporter/pkg/metrics"
@@ -300,11 +301,19 @@ func (r *Registry) GetSummary(metricName string, labels prometheus.Labels, help 
 		metricsCount.WithLabelValues("summary").Inc()
 		summaryOptions := r.Mapper.GetDefaultSummaryOptions()
 		if mapping != nil && mapping.SummaryOptions != nil {
-			summaryOptions = *mapping.SummaryOptions
-		}
-
-		if mapping != nil && mapping.SummaryOptions != nil && len(mapping.SummaryOptions.Quantiles) > 0 {
-			summaryOptions.Quantiles = mapping.SummaryOptions.Quantiles
+			tmp := mapping.SummaryOptions.Clone()
+			if len(tmp.Quantiles) > 0 {
+				summaryOptions.Quantiles = tmp.Quantiles
+			}
+			if tmp.BufCap != 0 {
+				summaryOptions.BufCap = tmp.BufCap
+			}
+			if tmp.AgeBuckets != 0 {
+				summaryOptions.AgeBuckets = tmp.AgeBuckets
+			}
+			if tmp.MaxAge != 0 {
+				summaryOptions.MaxAge = tmp.MaxAge
+			}
 		}
 
 		objectives := make(map[float64]float64)


### PR DESCRIPTION
This allows setting histogram_options and summary_options in the defaults section. I added some tests and refactored the mapper tests to use named subtests, but I still want to test it more thoroughly before I mark this as ready.

Feedback appreciated.

Fixes #336 @matthiasr 
