### PR TITLE
Support metric name segments starting with numbers

### DIFF
--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -28,10 +28,14 @@ import (
 )
 
 var (
-	statsdMetricRE    = `[a-zA-Z_](-?[a-zA-Z0-9_])*`
-	templateReplaceRE = `(\$\{?\d+\}?)`
+	// The first segment of a match cannot start with a number
+	statsdMetricRE = `[a-zA-Z_](-?[a-zA-Z0-9_])*`
+	// The subsequent segments of a match can start with a number
+	// See https://github.com/prometheus/statsd_exporter/issues/328
+	statsdMetricSubsequentRE = `[a-zA-Z0-9_](-?[a-zA-Z0-9_])*`
+	templateReplaceRE        = `(\$\{?\d+\}?)`
 
-	metricLineRE = regexp.MustCompile(`^(\*\.|` + statsdMetricRE + `\.)+(\*|` + statsdMetricRE + `)$`)
+	metricLineRE = regexp.MustCompile(`^(\*|` + statsdMetricRE + `)(\.\*|\.` + statsdMetricSubsequentRE + `)*$`)
 	metricNameRE = regexp.MustCompile(`^([a-zA-Z_]|` + templateReplaceRE + `)([a-zA-Z0-9_]|` + templateReplaceRE + `)*$`)
 	labelNameRE  = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]+$`)
 )

--- a/pkg/mapper/mapper_test.go
+++ b/pkg/mapper/mapper_test.go
@@ -338,7 +338,7 @@ mappings:
 			},
 		},
 		{
-			testName: "Match metric segment starting with a number",
+			testName: "Match metric segment with a number",
 			config: `
 mappings:
 - match: test.99.myapp.*
@@ -357,7 +357,26 @@ mappings:
 			},
 		},
 		{
-			testName: "Match metric segment starting with a number #328 example",
+			testName: "Match metric segment starting with a number",
+			config: `
+mappings:
+- match: test.99test.myapp.*
+  name: "name"
+  labels:
+    label: "${1}_foo"
+  `,
+			mappings: mappings{
+				{
+					statsdMetric: "test.99test.myapp.create",
+					name:         "name",
+					labels: map[string]string{
+						"label": "create_foo",
+					},
+				},
+			},
+		},
+		{
+			testName: "Match metric segment with a number #328 example",
 			config: `
 mappings:
 - match: kafka.server.FetcherStats.brokerHost.hostname.brokerPort.9092.clientId.ReplicaFetcherThread-0-1.BytesPerSec.1MinuteRate.gauge
@@ -367,6 +386,25 @@ mappings:
 				{
 					statsdMetric: "kafka.server.FetcherStats.brokerHost.hostname.brokerPort.9092.clientId.ReplicaFetcherThread-0-1.BytesPerSec.1MinuteRate.gauge",
 					name:         "example_name",
+				},
+			},
+		},
+		{
+			testName: "Single segment match",
+			config: `
+mappings:
+- match: '*'
+  name: single_segment
+  labels:
+    label: "${1}"
+`,
+			mappings: mappings{
+				{
+					statsdMetric: "test",
+					name:         "single_segment",
+					labels: map[string]string{
+						"label": "test",
+					},
 				},
 			},
 		},

--- a/pkg/mapper/mapper_test.go
+++ b/pkg/mapper/mapper_test.go
@@ -338,6 +338,39 @@ mappings:
 			},
 		},
 		{
+			testName: "Match metric segment starting with a number",
+			config: `
+mappings:
+- match: test.99.myapp.*
+  name: "name"
+  labels:
+    label: "${1}_foo"
+  `,
+			mappings: mappings{
+				{
+					statsdMetric: "test.99.myapp.create",
+					name:         "name",
+					labels: map[string]string{
+						"label": "create_foo",
+					},
+				},
+			},
+		},
+		{
+			testName: "Match metric segment starting with a number #328 example",
+			config: `
+mappings:
+- match: kafka.server.FetcherStats.brokerHost.hostname.brokerPort.9092.clientId.ReplicaFetcherThread-0-1.BytesPerSec.1MinuteRate.gauge
+  name: "example_name"
+  `,
+			mappings: mappings{
+				{
+					statsdMetric: "kafka.server.FetcherStats.brokerHost.hostname.brokerPort.9092.clientId.ReplicaFetcherThread-0-1.BytesPerSec.1MinuteRate.gauge",
+					name:         "example_name",
+				},
+			},
+		},
+		{
 			testName: "Config with bad metric line",
 			config: `---
 mappings:


### PR DESCRIPTION
Fixes #328 

Rework metricLineRE to support matching segments that start with a number. I'm not entirely sure that this is the exact use case, or that the tests duplicate the issue that @rayjcwu was describing, but it seems to work. The full regex used for matching glob patterns is below, and I think valid, but please double check. 
```
^(\*|[a-zA-Z_](-?[a-zA-Z0-9_])*)(\.\*|\.[a-zA-Z0-9_](-?[a-zA-Z0-9_])*)*$
```

The only other difference I think this change makes is that now `*` is valid , whereas previously I think it would have failed - is that in spec?

@matthiasr 
