### PR TITLE
filter empty metric name

### DIFF
--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -76,6 +76,11 @@ func (b *Exporter) Listen(e <-chan event.Events) {
 
 // handleEvent processes a single Event according to the configured mapping.
 func (b *Exporter) handleEvent(thisEvent event.Event) {
+	if thisEvent.MetricName() == "" {
+		level.Error(b.Logger).Log("msg", "metric name cannot be empty")
+		return
+	}
+
 	mapping, labels, present := b.Mapper.GetMapping(thisEvent.MetricName(), thisEvent.MetricType())
 	if mapping == nil {
 		mapping = &mapper.MetricMapping{}


### PR DESCRIPTION
Receiving an empty metric name results in an error in pulling the metric, such as

```sh
An error has occurred while serving metrics:

"" is not a valid metric name
```