### PR TITLE
Switch to cimg/go for build+test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
   # Whenever the Go version is updated here, .promu.yml should also be updated.
   golang:
     docker:
-      - image: circleci/golang:1.17
+      - image: cimg/go:1.17
 jobs:
   test:
     executor: golang


### PR DESCRIPTION
To get off the [deprecated] circleci/golang.

Fixes #424.

[deprecated]: https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034

Signed-off-by: Matthias Rampke <matthias@prometheus.io>