### PR TITLE
Fixing broken benchmark for mapper

### DIFF
--- a/pkg/mapper/mapper_benchmark_test.go
+++ b/pkg/mapper/mapper_benchmark_test.go
@@ -18,6 +18,8 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/go-kit/log"
+
 	"github.com/prometheus/statsd_exporter/pkg/mappercache/lru"
 	"github.com/prometheus/statsd_exporter/pkg/mappercache/randomreplacement"
 )
@@ -242,7 +244,9 @@ mappings:
 		"foo.bar.baz",
 	}
 
-	mapper := MetricMapper{}
+	mapper := MetricMapper{
+		Logger: log.NewNopLogger(),
+	}
 	err := mapper.InitFromYAMLString(config)
 	if err != nil {
 		b.Fatalf("Config load error: %s %s", config, err)


### PR DESCRIPTION
## Summary

During an investigation of resource usage in a branch of mine I noticed we
have broken benchmark for BenchmarkGlobNoOrderingWithBacktracking.
This is the only benchmark that needed the logger and it was breaking because
we were not passing a logger to the MetricMapper.
