### PR TITLE
Use IPv6 localhost for relay test

### DIFF
--- a/pkg/relay/relay_test.go
+++ b/pkg/relay/relay_test.go
@@ -45,8 +45,10 @@ func TestRelay_RelayLine(t *testing.T) {
 		},
 	}
 
+	const testAddr = "[::1]:1160"
+
 	for _, tt := range tests {
-		udp.SetAddr(":1160")
+		udp.SetAddr(testAddr)
 		t.Run(tt.name, func(t *testing.T) {
 			tickerCh := make(chan time.Time)
 			clock.ClockInstance = &clock.Clock{
@@ -57,7 +59,7 @@ func TestRelay_RelayLine(t *testing.T) {
 			logger := log.NewNopLogger()
 			r, err := NewRelay(
 				logger,
-				"localhost:1160",
+				testAddr,
 				200,
 			)
 
@@ -92,7 +94,7 @@ func TestRelay_RelayLine(t *testing.T) {
 				"statsd_exporter_relay_lines_relayed_total": float64(len(tt.args.lines)),
 			}
 			for metricName, expectedValue := range metricNames {
-				metric := getFloat64(metrics, metricName, prometheus.Labels{"target": "localhost:1160"})
+				metric := getFloat64(metrics, metricName, prometheus.Labels{"target": testAddr})
 
 				if metric == nil {
 					t.Fatalf("Could not find time series with first label set for metric: %s", metricName)


### PR DESCRIPTION
This is the only way I could find to make the test pass on _my_
macOS machine:

```
Darwin mr-6.local 21.5.0 Darwin Kernel Version 21.5.0: Tue Apr 26 21:08:37 PDT 2022; root:xnu-8020.121.3~4/RELEASE_ARM64_T6000 arm64
```

I don't understand the problem here, and I am not sure what the
implications are; this probably breaks the test on IPv4-only machines if
those still exist.

Without this change, or even when using 127.0.0.1, nothing is received.

```
=== RUN   TestRelay_RelayLine
=== RUN   TestRelay_RelayLine/multiple_lines
    udp.go:85: At: /Users/mr/src/github.com/prometheus/statsd_exporter/pkg/relay/relay_test.go:68
    udp.go:115: Expected to find: "foo5:100|c|#tag1:bar,#tag2:baz\n"
    udp.go:116: But got: ""
--- FAIL: TestRelay_RelayLine (0.00s)
    --- FAIL: TestRelay_RelayLine/multiple_lines (0.00s)
FAIL
FAIL	github.com/prometheus/statsd_exporter/pkg/relay	1.809s
FAIL
```

Is there a better or more well understood solution?

Possibly related: `localhost` is [not well defined](https://github.com/golang/go/issues/22826).

Signed-off-by: Matthias Rampke <matthias@prometheus.io>