### PR TITLE
mapper: Make sure we have a logger before backtracking check

### DIFF
--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -233,6 +233,10 @@ func (m *MetricMapper) InitFromYAMLString(fileContents string) error {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
+	if m.Logger == nil {
+		m.Logger = log.NewNopLogger()
+	}
+
 	m.Defaults = n.Defaults
 	m.Mappings = n.Mappings
 
@@ -257,10 +261,6 @@ func (m *MetricMapper) InitFromYAMLString(fileContents string) error {
 
 	if m.MappingsCount != nil {
 		m.MappingsCount.Set(float64(len(n.Mappings)))
-	}
-
-	if m.Logger == nil {
-		m.Logger = log.NewNopLogger()
 	}
 
 	return nil


### PR DESCRIPTION
The FSM backtracking detection issues a log line. Make sure there is a
non-nil logger before doing that.

Avoids the crash in prometheus/graphite_exporter#197.

Signed-off-by: Matthias Rampke <matthias@prometheus.io>