### PR TITLE
Remove ioutil

### DIFF
--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -15,7 +15,7 @@ package mapper
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"sync"
 	"time"
@@ -267,7 +267,7 @@ func (m *MetricMapper) InitFromYAMLString(fileContents string) error {
 }
 
 func (m *MetricMapper) InitFromFile(fileName string) error {
-	mappingStr, err := ioutil.ReadFile(fileName)
+	mappingStr, err := os.ReadFile(fileName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
`ioutil` is deprecated from go1.16 (ref: https://go.dev/doc/go1.16#ioutil).
So removed them.

Signed-off-by: inosato <si17_21@yahoo.co.jp>