### PR TITLE
Performance improvement - Introduce queue for raw statsd payloads

### DIFF
--- a/exporter_benchmark_test.go
+++ b/exporter_benchmark_test.go
@@ -17,6 +17,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/prometheus/statsd_exporter/pkg/parser"
+
 	"github.com/go-kit/log"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -50,11 +52,11 @@ func benchmarkUDPListener(times int, b *testing.B) {
 		}
 	}
 
-	parser := line.NewParser()
-	parser.EnableDogstatsdParsing()
-	parser.EnableInfluxdbParsing()
-	parser.EnableLibratoParsing()
-	parser.EnableSignalFXParsing()
+	testParser := line.NewParser()
+	testParser.EnableDogstatsdParsing()
+	testParser.EnableInfluxdbParsing()
+	testParser.EnableLibratoParsing()
+	testParser.EnableSignalFXParsing()
 
 	// reset benchmark timer to not measure startup costs
 	b.ResetTimer()
@@ -65,25 +67,39 @@ func benchmarkUDPListener(times int, b *testing.B) {
 
 		// there are more events than input lines, need bigger buffer
 		events := make(chan event.Events, len(bytesInput)*times*2)
+		packets := make(chan string, len(input)*times*2)
 
 		l := listener.StatsDUDPListener{
-			EventHandler:    &event.UnbufferedEventHandler{C: events},
-			Logger:          logger,
-			LineParser:      parser,
-			UDPPackets:      udpPackets,
-			LinesReceived:   linesReceived,
-			SamplesReceived: samplesReceived,
-			TagsReceived:    tagsReceived,
+			Logger:       logger,
+			UDPPackets:   udpPackets,
+			PacketBuffer: packets,
+		}
+
+		workers := make([]*parser.Worker, 2)
+		for i := 0; i < len(workers); i++ {
+			workers[i] = parser.NewWorker(
+				logger,
+				&event.UnbufferedEventHandler{C: events},
+				testParser,
+				nil,
+				linesReceived,
+				*sampleErrors,
+				samplesReceived,
+				tagErrors,
+				tagsReceived,
+			)
+			go workers[i].Consume(packets)
 		}
 
 		// resume benchmark timer
 		b.StartTimer()
 
 		for i := 0; i < times; i++ {
-			for _, line := range bytesInput {
-				l.HandlePacket([]byte(line))
+			for _, li := range bytesInput {
+				l.HandlePacket([]byte(li))
 			}
 		}
+		close(packets)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/prometheus/client_golang v1.12.2
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.37.0
+	github.com/stretchr/testify v1.4.0
 	github.com/stvp/go-udp-testing v0.0.0-20201019212854-469649b16807
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/yaml.v2 v2.4.0
@@ -18,9 +19,11 @@ require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d // indirect
 	google.golang.org/protobuf v1.28.0 // indirect

--- a/main.go
+++ b/main.go
@@ -473,9 +473,8 @@ func main() {
 		}
 	}
 
-	workers := make([]*parser.Worker, *parserWorkerPool)
 	for i := 0; i < int(*parserWorkerPool); i++ {
-		workers[i] = parser.NewWorker(
+		worker := parser.NewWorker(
 			logger,
 			eventQueue,
 			lineParser,
@@ -486,7 +485,7 @@ func main() {
 			tagErrors,
 			tagsReceived,
 		)
-		go workers[i].Consume(packets)
+		go worker.Consume(packets)
 	}
 
 	mux := http.DefaultServeMux

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -118,7 +118,7 @@ func (eq *EventQueue) Flush() {
 
 func (eq *EventQueue) FlushUnlocked() {
 	eq.C <- eq.q
-	eq.q = make([]Event, 0, cap(eq.q))
+	eq.q = eq.q[:0]
 	eq.eventsFlushed.Inc()
 }
 

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -118,7 +118,7 @@ func (eq *EventQueue) Flush() {
 
 func (eq *EventQueue) FlushUnlocked() {
 	eq.C <- eq.q
-	eq.q = eq.q[:0]
+	eq.q = make([]Event, 0, eq.flushThreshold)
 	eq.eventsFlushed.Inc()
 }
 

--- a/pkg/parser/worker.go
+++ b/pkg/parser/worker.go
@@ -1,0 +1,86 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"strings"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/statsd_exporter/pkg/event"
+	"github.com/prometheus/statsd_exporter/pkg/line"
+	"github.com/prometheus/statsd_exporter/pkg/relay"
+)
+
+type Worker struct {
+	EventHandler event.EventHandler
+	Logger       log.Logger
+	LineParser   *line.Parser
+	Relay        *relay.Relay
+
+	LinesReceived   prometheus.Counter
+	SampleErrors    prometheus.CounterVec
+	SamplesReceived prometheus.Counter
+	TagErrors       prometheus.Counter
+	TagsReceived    prometheus.Counter
+}
+
+func NewWorker(
+	logger log.Logger,
+	eventHandler event.EventHandler,
+	lineParser *line.Parser,
+	relay *relay.Relay,
+	linesReceived prometheus.Counter,
+	sampleErrors prometheus.CounterVec,
+	samplesReceived prometheus.Counter,
+	tagErrors prometheus.Counter,
+	tagsReceived prometheus.Counter,
+) *Worker {
+	return &Worker{
+		EventHandler:    eventHandler,
+		Logger:          logger,
+		LineParser:      lineParser,
+		Relay:           relay,
+		LinesReceived:   linesReceived,
+		SampleErrors:    sampleErrors,
+		SamplesReceived: samplesReceived,
+		TagErrors:       tagErrors,
+		TagsReceived:    tagsReceived,
+	}
+}
+
+func (w *Worker) Consume(c <-chan string) {
+	for {
+		bytes, ok := <-c
+
+		if !ok {
+			level.Debug(w.Logger).Log("msg", "channel closed, exiting consume loop")
+			return
+		}
+		w.handle(bytes)
+	}
+}
+
+func (w *Worker) handle(packet string) {
+	lines := strings.Split(packet, "\n")
+	for _, l := range lines {
+		level.Debug(w.Logger).Log("msg", "Incoming line", "sample", l)
+		w.LinesReceived.Inc()
+		if w.Relay != nil && len(l) > 0 {
+			w.Relay.RelayLine(l)
+		}
+		w.EventHandler.Queue(w.LineParser.LineToEvents(l, w.SampleErrors, w.SamplesReceived, w.TagErrors, w.TagsReceived, w.Logger))
+	}
+}


### PR DESCRIPTION
## Summary of this PR

In this PR I am introducing a queue for raw statsd payloads (calling them packets), and a worker pool to parse the packets in a parallel manner.

## Problem

I am currently managing a fleet of statsd exporters for a project and I noticed it suffers to keep up with high traffic applications. I have observed memory spikes that goes over 500Mib and when profiling those high memory usage instances I could see the hot path was mostly in statsd parsing ([see example heap profile](https://user-images.githubusercontent.com/2609731/185636434-20f2c89c-5544-4a3b-aab8-4443e12a5a00.png)).

I could not reach a conclusion on what exactly was causing the memory, I suspected at first it was the GC not being able to react fast enough to the burst of data or dangling references to the maps that get created while parsing tags.
Some things I have tried:

* Play with `GOGC` and try to make GC more aggressive: this yielded limited success, in general memory was lower, but we still saw spikes and OOM kills.
* Build the exporter with Go 1.19, set GOMEMLIMIT: almost same result as GOGC with more stability, but nevertheless OOM kills (with the limits we thing are acceptable for our case).
* To make sure it was a problem with the rate of which payloads get delivered to the exporter we tried rate-limiting with a custom tool before the exporter, this gave a good result, but metric correctness was hurt so we could not use it.


## Solution

Using knowledge of applications my team already built in the past and by looking at the code from the [Datadog Agent](https://github.com/DataDog/datadog-agent), I tried to introduce a "buffer" for statsd payloads *before* the exporter starts parsing the payloads. By doing this you free the "wire" of the UDP connection faster and allow for parallelism on the hard job that is parsing (hot path of heap allocation).

Apart from that, I moved the parsing from each listener to a pool of "workers" which are responsible for doing the work of parsing, relaying and send events to the EventQueue.


## Results

1. First of all **we don't have observed OOM Kills anymore**, even under higher loads (12 Mib/s of payload traffic).
2. **Memory usage** and spikes are **much lower**, also CPU throttle went away.
![image](https://user-images.githubusercontent.com/2609731/185640720-b5fed84e-42e6-4a3e-99db-128775b479c2.png)

### Bench comparison

I am omitting the benchmarks that are equal (parsing, line format, etc).

```
▶ benchstat /tmp/master-bench.txt /tmp/new-bench           
name                            old time/op    new time/op    delta
UDPListener1-8                    8.46µs ± 0%    3.39µs ± 0%   ~     (p=1.000 n=1+1)
UDPListener5-8                     179µs ± 0%     178µs ± 0%   ~     (p=1.000 n=1+1)
UDPListener50-8                   19.7ms ± 0%    17.7ms ± 0%   ~     (p=1.000 n=1+1)
ExporterListener-8                5.44ms ± 0%    6.07ms ± 0%   ~     (p=1.000 n=1+1)
LineToEventsMixed1-8              5.45µs ± 0%    6.14µs ± 0%   ~     (p=1.000 n=1+1)
LineToEventsMixed5-8              27.3µs ± 0%    30.9µs ± 0%   ~     (p=1.000 n=1+1)
LineToEventsMixed50-8              277µs ± 0%     308µs ± 0%   ~     (p=1.000 n=1+1)
LineFormats/dogStatsd-8            390ns ± 0%     454ns ± 0%   ~     (p=1.000 n=1+1)
LineFormats/invalidDogStatsd-8     468ns ± 0%     539ns ± 0%   ~     (p=1.000 n=1+1)
LineFormats/signalFx-8             411ns ± 0%     472ns ± 0%   ~     (p=1.000 n=1+1)
LineFormats/invalidSignalFx-8      303ns ± 0%     348ns ± 0%   ~     (p=1.000 n=1+1)
LineFormats/influxDb-8             381ns ± 0%     453ns ± 0%   ~     (p=1.000 n=1+1)
LineFormats/invalidInfluxDb-8      435ns ± 0%     529ns ± 0%   ~     (p=1.000 n=1+1)
LineFormats/statsd-8               254ns ± 0%     281ns ± 0%   ~     (p=1.000 n=1+1)
LineFormats/invalidStatsd-8        392ns ± 0%     431ns ± 0%   ~     (p=1.000 n=1+1)

name                            old alloc/op   new alloc/op   delta
UDPListener1-8                    6.85kB ± 0%    5.25kB ± 0%   ~     (p=1.000 n=1+1)
UDPListener5-8                     171kB ± 0%     222kB ± 0%   ~     (p=1.000 n=1+1)
UDPListener50-8                   17.1MB ± 0%    22.3MB ± 0%   ~     (p=1.000 n=1+1)
ExporterListener-8                3.44MB ± 0%    3.44MB ± 0%   ~     (p=1.000 n=1+1)
LineToEventsMixed1-8              4.56kB ± 0%    4.56kB ± 0%   ~     (p=1.000 n=1+1)
LineToEventsMixed5-8              22.8kB ± 0%    22.8kB ± 0%   ~     (p=1.000 n=1+1)
LineToEventsMixed50-8              228kB ± 0%     228kB ± 0%   ~     (p=1.000 n=1+1)
```


## Future TODOs

There are some things I would like to have, but I will leave them for another PR to avoid making this PR too big to review:

* I want to introduce metric for the size of both queues, we did that in other application by wrapping metric handler and passing the channels to them and calling `len()` before reporting metrics.

