### PR TITLE
Counter with histogram suffix will clash with histogram

### DIFF
--- a/pkg/exporter/exporter_test.go
+++ b/pkg/exporter/exporter_test.go
@@ -520,10 +520,11 @@ mappings:
 				events <- s.in
 				close(events)
 			}()
-			ex := NewExporter(prometheus.DefaultRegisterer, testMapper, log.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount)
+			registerer := prometheus.NewRegistry()
+			ex := NewExporter(registerer, testMapper, log.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount)
 			ex.Listen(events)
 
-			metrics, err := prometheus.DefaultGatherer.Gather()
+			metrics, err := registerer.Gather()
 			if err != nil {
 				t.Fatalf("Cannot gather from DefaultGatherer: %v", err)
 			}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -19,6 +19,7 @@ import (
 	"hash"
 	"hash/fnv"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -163,6 +164,15 @@ func (r *Registry) GetCounter(metricName string, labels prometheus.Labels, help 
 
 	if r.MetricConflicts(metricName, metrics.CounterMetricType) {
 		return nil, fmt.Errorf("metric with name %s is already registered", metricName)
+	}
+
+	histogramSuffixes := []string{"_bucket", "_count", "_sum"}
+	for _, suffix := range histogramSuffixes {
+		if strings.HasSuffix(metricName, suffix) {
+			if r.MetricConflicts(strings.TrimSuffix(metricName, suffix), metrics.CounterMetricType) {
+				return nil, fmt.Errorf("metric with name %s is already registered", metricName)
+			}
+		}
 	}
 
 	var counterVec *prometheus.CounterVec


### PR DESCRIPTION
## Summary

While running the exporter in production a colegue faced an error when a counter clashes with a previously collected histogram.
I managed to reproduce the bug with some tests cases and this PR fixes the problem.


## Bug description

The problem can be reproduced in the following manner.

1. A sample `foo:1|h` (a histogram - to be translated to a prometheus histogram) is sent to the exporter.
2. The exporter will register `foo_count`, `foo_sum` and `foo_bucket`.
3. Later a sample `foo_count:1|c` arrives at the exporter, the exporter will also register the counter.
4. The gatherer will detect that this counter is not part of the histogram, but a separate counter and will crash.

## Changes

- Fix the described bug, by checking for existing histograms before registering the counters.
- Improve isolation of test case `TestConflictingMetrics()` by using a new Prometheus registry for each test run.

