### PR TITLE
Print version, help etc to stdout

### DIFF
--- a/main.go
+++ b/main.go
@@ -265,6 +265,7 @@ func main() {
 	promlogConfig := &promlog.Config{}
 	flag.AddFlags(kingpin.CommandLine, promlogConfig)
 	kingpin.Version(version.Print("statsd_exporter"))
+	kingpin.CommandLine.UsageWriter(os.Stdout)
 	kingpin.HelpFlag.Short('h')
 	kingpin.Parse()
 	logger := promlog.New(promlogConfig)


### PR DESCRIPTION
The default behavior of kingpin lib is to print stuff to stderr. This is now changed by using the os.Stdout writer. Now information like version and help text will be printed to stdout.