### PR TITLE
Prefixed glob matches

### DIFF
--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -30,10 +30,10 @@ import (
 
 var (
 	// The first segment of a match cannot start with a number
-	statsdMetricRE = `[a-zA-Z_]([a-zA-Z0-9_\-])*`
+	statsdMetricRE = `[a-zA-Z_]([a-zA-Z0-9_\-\*])*`
 	// The subsequent segments of a match can start with a number
 	// See https://github.com/prometheus/statsd_exporter/issues/328
-	statsdMetricSubsequentRE = `[a-zA-Z0-9_]([a-zA-Z0-9_\-])*`
+	statsdMetricSubsequentRE = `[a-zA-Z0-9_]([a-zA-Z0-9_\-\*])*`
 	templateReplaceRE        = `(\$\{?\d+\}?)`
 
 	metricLineRE = regexp.MustCompile(`^(\*|` + statsdMetricRE + `)(\.\*|\.` + statsdMetricSubsequentRE + `)*$`)

--- a/pkg/mapper/mapper_test.go
+++ b/pkg/mapper/mapper_test.go
@@ -95,6 +95,11 @@ mappings:
     ipv4_t4: "${10}"
     orgid: "${11}"
     oauthid: "${12}"
+- match: "prefixed_glob.prefix_*.*"
+  name: prefixed_glob
+  labels:
+    prefix: "${1}"
+    metric: "${2}"
 - match: "*.*"
   name: "catchall"
   labels:
@@ -149,6 +154,14 @@ mappings:
 						"ipv4_t4":         "1",
 						"orgid":           "12ba97b7eaa1a50001000001",
 						"oauthid":         "",
+					},
+				},
+				{
+					statsdMetric: "prefixed_glob.prefix_myprefix.mymetric",
+					name:         "prefixed_glob",
+					labels: map[string]string{
+						"prefix": "myprefix",
+						"metric": "mymetric",
 					},
 				},
 				{


### PR DESCRIPTION
This is just a setup for https://github.com/prometheus/statsd_exporter/issues/481 which allows prefixed globs to reach the state machine.

The hard work of actually supporting them still needs to get done before this can be proposed for merge.