### PR TITLE
Making mapperConfigDefaults public

### DIFF
--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -43,7 +43,7 @@ var (
 
 type MetricMapper struct {
 	Registerer prometheus.Registerer
-	Defaults   mapperConfigDefaults `yaml:"defaults"`
+	Defaults   MapperConfigDefaults `yaml:"defaults"`
 	Mappings   []MetricMapping      `yaml:"mappings"`
 	FSM        *fsm.FSM
 	doFSM      bool
@@ -57,7 +57,7 @@ type MetricMapper struct {
 }
 
 type SummaryOptions struct {
-	Quantiles  []metricObjective `yaml:"quantiles"`
+	Quantiles  []MetricObjective `yaml:"quantiles"`
 	MaxAge     time.Duration     `yaml:"max_age"`
 	AgeBuckets uint32            `yaml:"age_buckets"`
 	BufCap     uint32            `yaml:"buf_cap"`
@@ -69,12 +69,12 @@ type HistogramOptions struct {
 	NativeHistogramMaxBuckets   uint32    `yaml:"native_histogram_max_buckets"`
 }
 
-type metricObjective struct {
+type MetricObjective struct {
 	Quantile float64 `yaml:"quantile"`
 	Error    float64 `yaml:"error"`
 }
 
-var defaultQuantiles = []metricObjective{
+var defaultQuantiles = []MetricObjective{
 	{Quantile: 0.5, Error: 0.05},
 	{Quantile: 0.9, Error: 0.01},
 	{Quantile: 0.99, Error: 0.001},

--- a/pkg/mapper/mapper_defaults.go
+++ b/pkg/mapper/mapper_defaults.go
@@ -15,7 +15,7 @@ package mapper
 
 import "time"
 
-type mapperConfigDefaults struct {
+type MapperConfigDefaults struct {
 	ObserverType        ObserverType     `yaml:"observer_type"`
 	MatchType           MatchType        `yaml:"match_type"`
 	GlobDisableOrdering bool             `yaml:"glob_disable_ordering"`
@@ -29,7 +29,7 @@ type mapperConfigDefaultsAlias struct {
 	ObserverType        ObserverType      `yaml:"observer_type"`
 	TimerType           ObserverType      `yaml:"timer_type,omitempty"` // DEPRECATED - field only present to preserve backwards compatibility in configs
 	Buckets             []float64         `yaml:"buckets"`              // DEPRECATED - field only present to preserve backwards compatibility in configs
-	Quantiles           []metricObjective `yaml:"quantiles"`            // DEPRECATED - field only present to preserve backwards compatibility in configs
+	Quantiles           []MetricObjective `yaml:"quantiles"`            // DEPRECATED - field only present to preserve backwards compatibility in configs
 	MatchType           MatchType         `yaml:"match_type"`
 	GlobDisableOrdering bool              `yaml:"glob_disable_ordering"`
 	Ttl                 time.Duration     `yaml:"ttl"`
@@ -39,7 +39,7 @@ type mapperConfigDefaultsAlias struct {
 
 // UnmarshalYAML is a custom unmarshal function to allow use of deprecated config keys
 // observer_type will override timer_type
-func (d *mapperConfigDefaults) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (d *MapperConfigDefaults) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var tmp mapperConfigDefaultsAlias
 	if err := unmarshal(&tmp); err != nil {
 		return err

--- a/pkg/mapper/mapper_test.go
+++ b/pkg/mapper/mapper_test.go
@@ -27,7 +27,7 @@ type mappings []struct {
 	statsdMetric string
 	name         string
 	labels       map[string]string
-	quantiles    []metricObjective
+	quantiles    []MetricObjective
 	notPresent   bool
 	ttl          time.Duration
 	metricType   MetricType
@@ -570,7 +570,7 @@ mappings:
 					statsdMetric: "test.*.*",
 					name:         "foo",
 					labels:       map[string]string{},
-					quantiles: []metricObjective{
+					quantiles: []MetricObjective{
 						{Quantile: 0.42, Error: 0.04},
 						{Quantile: 0.7, Error: 0.002},
 					},
@@ -597,7 +597,7 @@ mappings:
 					statsdMetric: "test.*.*",
 					name:         "foo",
 					labels:       map[string]string{},
-					quantiles: []metricObjective{
+					quantiles: []MetricObjective{
 						{Quantile: 0.42, Error: 0.04},
 						{Quantile: 0.7, Error: 0.002},
 					},
@@ -618,7 +618,7 @@ mappings:
 					statsdMetric: "test1.*.*",
 					name:         "foo",
 					labels:       map[string]string{},
-					quantiles: []metricObjective{
+					quantiles: []MetricObjective{
 						{Quantile: 0.5, Error: 0.05},
 						{Quantile: 0.9, Error: 0.01},
 						{Quantile: 0.99, Error: 0.001},
@@ -640,7 +640,7 @@ mappings:
 					statsdMetric: "test1.*.*",
 					name:         "foo",
 					labels:       map[string]string{},
-					quantiles: []metricObjective{
+					quantiles: []MetricObjective{
 						{Quantile: 0.5, Error: 0.05},
 						{Quantile: 0.9, Error: 0.01},
 						{Quantile: 0.99, Error: 0.001},
@@ -690,7 +690,7 @@ mappings:
 					statsdMetric: "test.*.*",
 					name:         "foo",
 					labels:       map[string]string{},
-					quantiles: []metricObjective{
+					quantiles: []MetricObjective{
 						{Quantile: 0.42, Error: 0.04},
 						{Quantile: 0.7, Error: 0.002},
 					},
@@ -720,7 +720,7 @@ mappings:
 					statsdMetric: "test.*.*",
 					name:         "foo",
 					labels:       map[string]string{},
-					quantiles: []metricObjective{
+					quantiles: []MetricObjective{
 						{Quantile: 0.42, Error: 0.04},
 						{Quantile: 0.7, Error: 0.002},
 					},
@@ -754,7 +754,7 @@ mappings:
 					statsdMetric: "test.*.*",
 					name:         "foo",
 					labels:       map[string]string{},
-					quantiles: []metricObjective{
+					quantiles: []MetricObjective{
 						{Quantile: 0.42, Error: 0.04},
 						{Quantile: 0.7, Error: 0.002},
 					},
@@ -819,7 +819,7 @@ mappings:
 					statsdMetric: "test.*.*",
 					name:         "foo",
 					labels:       map[string]string{},
-					quantiles: []metricObjective{
+					quantiles: []MetricObjective{
 						{Quantile: 0.42, Error: 0.04},
 						{Quantile: 0.7, Error: 0.002},
 					},
@@ -862,7 +862,7 @@ mappings:
 					statsdMetric: "test.*.*",
 					name:         "foo",
 					labels:       map[string]string{},
-					quantiles: []metricObjective{
+					quantiles: []MetricObjective{
 						{Quantile: 0.42, Error: 0.04},
 						{Quantile: 0.7, Error: 0.002},
 					},
@@ -909,7 +909,7 @@ mappings:
 					statsdMetric: "test.*.*",
 					name:         "foo",
 					labels:       map[string]string{},
-					quantiles: []metricObjective{
+					quantiles: []MetricObjective{
 						{Quantile: 0.42, Error: 0.04},
 						{Quantile: 0.7, Error: 0.002},
 					},
@@ -921,7 +921,7 @@ mappings:
 					statsdMetric: "test_default.*.*",
 					name:         "foo_default",
 					labels:       map[string]string{},
-					quantiles: []metricObjective{
+					quantiles: []MetricObjective{
 						{Quantile: 0.9, Error: 0.1},
 						{Quantile: 0.99, Error: 0.01},
 					},
@@ -965,7 +965,7 @@ mappings:
 					statsdMetric: "test.*.*",
 					name:         "foo",
 					labels:       map[string]string{},
-					quantiles: []metricObjective{
+					quantiles: []MetricObjective{
 						{Quantile: 0.42, Error: 0.04},
 						{Quantile: 0.7, Error: 0.002},
 					},
@@ -977,7 +977,7 @@ mappings:
 					statsdMetric: "test_default.*.*",
 					name:         "foo_default",
 					labels:       map[string]string{},
-					quantiles: []metricObjective{
+					quantiles: []MetricObjective{
 						{Quantile: 0.9, Error: 0.1},
 						{Quantile: 0.99, Error: 0.01},
 					},
@@ -1017,7 +1017,7 @@ mappings:
 					statsdMetric: "test.*.*",
 					name:         "foo",
 					labels:       map[string]string{},
-					quantiles: []metricObjective{
+					quantiles: []MetricObjective{
 						{Quantile: 0.9, Error: 0.1},
 						{Quantile: 0.99, Error: 0.01},
 					},
@@ -1029,7 +1029,7 @@ mappings:
 					statsdMetric: "test_default.*.*",
 					name:         "foo_default",
 					labels:       map[string]string{},
-					quantiles: []metricObjective{
+					quantiles: []MetricObjective{
 						{Quantile: 0.9, Error: 0.1},
 						{Quantile: 0.99, Error: 0.01},
 					},

--- a/pkg/mapper/mapping.go
+++ b/pkg/mapper/mapping.go
@@ -33,7 +33,7 @@ type MetricMapping struct {
 	ObserverType     ObserverType      `yaml:"observer_type"`
 	TimerType        ObserverType      `yaml:"timer_type,omitempty"` // DEPRECATED - field only present to preserve backwards compatibility in configs. Always empty
 	LegacyBuckets    []float64         `yaml:"buckets"`
-	LegacyQuantiles  []metricObjective `yaml:"quantiles"`
+	LegacyQuantiles  []MetricObjective `yaml:"quantiles"`
 	MatchType        MatchType         `yaml:"match_type"`
 	HelpText         string            `yaml:"help"`
 	Action           ActionType        `yaml:"action"`


### PR DESCRIPTION
This is making the `mapperConfigDefaults` and  `metricObjective` structs inside `MetricMapper` object public, so that Grafana Agent or any other application embedding this exporter can instatiate `MetricMapper` without using the `InitFromYAMLString` directly.

This is really helpful when you are not defining your configuration using YAML standard.