### PR TITLE
Add `scale` field to mapping config

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,23 @@ metrics that do not expire.
  expire a metric only by changing the mapping configuration. At least one
  sample must be received for updated mappings to take effect.
 
+### Unit conversions
+
+The `scale` parameter can be used to define unit conversions for metric values. The value is a floating point number to scale metric values by. This can be useful for converting non-base units (e.g. milliseconds, kilobytes) to base units (e.g. seconds, bytes) as recommended in [prometheus best practices](https://prometheus.io/docs/practices/naming/).
+
+```yaml
+mappings:
+- match: foo.latency_ms
+  name: foo_latency_seconds
+  scale: 0.001
+- match: bar.processed_kb
+  name: bar_processed_bytes
+  scale: 1024
+- match: baz.latency_us
+  name: baz_latency_seconds
+  scale: 1e-6
+```
+
  ### Event flushing configuration
 
  Internally `statsd_exporter` runs a goroutine for each network listener (UDP, TCP & Unix Socket).  These each receive and parse metrics received into an event.  For performance purposes, these events are queued internally and flushed to the main exporter goroutine periodically in batches.  The size of this queue and the flush criteria can be tuned with the `--statsd.event-queue-size`, `--statsd.event-flush-threshold` and `--statsd.event-flush-interval`.  However, the defaults should perform well even for very high traffic environments.

--- a/pkg/mapper/mapping.go
+++ b/pkg/mapper/mapping.go
@@ -41,6 +41,7 @@ type MetricMapping struct {
 	Ttl              time.Duration     `yaml:"ttl"`
 	SummaryOptions   *SummaryOptions   `yaml:"summary_options"`
 	HistogramOptions *HistogramOptions `yaml:"histogram_options"`
+	Scale            MaybeFloat64      `yaml:"scale"`
 }
 
 // UnmarshalYAML is a custom unmarshal function to allow use of deprecated config keys
@@ -66,11 +67,34 @@ func (m *MetricMapping) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	m.Ttl = tmp.Ttl
 	m.SummaryOptions = tmp.SummaryOptions
 	m.HistogramOptions = tmp.HistogramOptions
+	m.Scale = tmp.Scale
 
 	// Use deprecated TimerType if necessary
 	if tmp.ObserverType == "" {
 		m.ObserverType = tmp.TimerType
 	}
 
+	return nil
+}
+
+type MaybeFloat64 struct {
+	Set bool
+	Val float64
+}
+
+func (m *MaybeFloat64) MarshalYAML() (interface{}, error) {
+	if m.Set {
+		return m.Val, nil
+	}
+	return nil, nil
+}
+
+func (m *MaybeFloat64) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var tmp float64
+	if err := unmarshal(&tmp); err != nil {
+		return err
+	}
+	m.Val = tmp
+	m.Set = true
 	return nil
 }


### PR DESCRIPTION
Fixes https://github.com/prometheus/statsd_exporter/issues/498

This field allows configuring unit conversions in mappings. This is important for following [prometheus best practices](https://prometheus.io/docs/practices/naming/), which states that metrics should use base units (e.g. seconds, not milliseconds). For example:

```yaml
mappings:
- match: foo.latency_ms
  name: foo_latency_seconds
  scale: 0.001
- match: bar.processed_kb
  name: bar_processed_bytes
  scale: 1024
```