### PR TITLE
Performance improvement - process udp packets in separate goroutine in order to minimize packet drops

### DIFF
--- a/bridge_test.go
+++ b/bridge_test.go
@@ -543,6 +543,7 @@ func TestHandlePacket(t *testing.T) {
 		Logger:          log.NewNopLogger(),
 		LineParser:      parser,
 		UDPPackets:      udpPackets,
+		UDPPacketDrops:  udpPacketDrops,
 		LinesReceived:   linesReceived,
 		EventsFlushed:   eventsFlushed,
 		SampleErrors:    *sampleErrors,

--- a/exporter_benchmark_test.go
+++ b/exporter_benchmark_test.go
@@ -65,6 +65,7 @@ func benchmarkUDPListener(times int, b *testing.B) {
 
 		// there are more events than input lines, need bigger buffer
 		events := make(chan event.Events, len(bytesInput)*times*2)
+		udpChan := make(chan []byte, len(bytesInput)*times*2)
 
 		l := listener.StatsDUDPListener{
 			EventHandler:    &event.UnbufferedEventHandler{C: events},
@@ -74,6 +75,7 @@ func benchmarkUDPListener(times int, b *testing.B) {
 			LinesReceived:   linesReceived,
 			SamplesReceived: samplesReceived,
 			TagsReceived:    tagsReceived,
+			UdpPacketQueue:  udpChan,
 		}
 
 		// resume benchmark timer

--- a/main.go
+++ b/main.go
@@ -71,6 +71,12 @@ var (
 			Help: "The total number of StatsD packets received over UDP.",
 		},
 	)
+	udpPacketDrops = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "statsd_exporter_udp_packet_drops_total",
+			Help: "The total number of dropped StatsD packets which received over UDP.",
+		},
+	)
 	tcpConnections = promauto.NewCounter(
 		prometheus.CounterOpts{
 			Name: "statsd_exporter_tcp_connections_total",
@@ -377,6 +383,7 @@ func main() {
 			Logger:          logger,
 			LineParser:      parser,
 			UDPPackets:      udpPackets,
+			UDPPacketDrops:  udpPacketDrops,
 			LinesReceived:   linesReceived,
 			EventsFlushed:   eventsFlushed,
 			Relay:           relayTarget,

--- a/main.go
+++ b/main.go
@@ -267,7 +267,7 @@ func main() {
 		signalFXTagsEnabled  = kingpin.Flag("statsd.parse-signalfx-tags", "Parse SignalFX style tags. Enabled by default.").Default("true").Bool()
 		relayAddr            = kingpin.Flag("statsd.relay.address", "The UDP relay target address (host:port)").String()
 		relayPacketLen       = kingpin.Flag("statsd.relay.packet-length", "Maximum relay output packet length to avoid fragmentation").Default("1400").Uint()
-		udpPacketQueueSize   = kingpin.Flag("statsd.udp-packet-queue-size", "Size of internal queue for processing udp packets.").Default("10000").Int()
+		udpPacketQueueSize   = kingpin.Flag("statsd.udp-packet-queue-size", "Size of internal queue for processing UDP packets.").Default("10000").Int()
 	)
 
 	promlogConfig := &promlog.Config{}

--- a/main.go
+++ b/main.go
@@ -261,6 +261,7 @@ func main() {
 		signalFXTagsEnabled  = kingpin.Flag("statsd.parse-signalfx-tags", "Parse SignalFX style tags. Enabled by default.").Default("true").Bool()
 		relayAddr            = kingpin.Flag("statsd.relay.address", "The UDP relay target address (host:port)").String()
 		relayPacketLen       = kingpin.Flag("statsd.relay.packet-length", "Maximum relay output packet length to avoid fragmentation").Default("1400").Uint()
+		udpPacketQueueSize   = kingpin.Flag("statsd.udp-packet-queue-size", "Size of internal queue for processing udp packets.").Default("10000").Int()
 	)
 
 	promlogConfig := &promlog.Config{}
@@ -368,6 +369,8 @@ func main() {
 			}
 		}
 
+		udpPacketQueue := make(chan []byte, *udpPacketQueueSize)
+
 		ul := &listener.StatsDUDPListener{
 			Conn:            uconn,
 			EventHandler:    eventQueue,
@@ -381,6 +384,7 @@ func main() {
 			SamplesReceived: samplesReceived,
 			TagErrors:       tagErrors,
 			TagsReceived:    tagsReceived,
+			UdpPacketQueue:  udpPacketQueue,
 		}
 
 		go ul.Listen()

--- a/pkg/exporter/exporter_test.go
+++ b/pkg/exporter/exporter_test.go
@@ -56,6 +56,12 @@ var (
 			Help: "The total number of StatsD packets received over UDP.",
 		},
 	)
+	udpPacketDrops = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "statsd_exporter_udp_packet_drops_total",
+			Help: "The total number of dropped StatsD packets which received over UDP.",
+		},
+	)
 	tcpConnections = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Name: "statsd_exporter_tcp_connections_total",
@@ -683,6 +689,7 @@ func TestInvalidUtf8InDatadogTagValue(t *testing.T) {
 			Logger:          log.NewNopLogger(),
 			LineParser:      parser,
 			UDPPackets:      udpPackets,
+			UDPPacketDrops:  udpPacketDrops,
 			LinesReceived:   linesReceived,
 			EventsFlushed:   eventsFlushed,
 			SampleErrors:    *sampleErrors,

--- a/pkg/listener/listener.go
+++ b/pkg/listener/listener.go
@@ -71,6 +71,7 @@ func (l *StatsDUDPListener) Listen() {
 }
 
 func (l *StatsDUDPListener) EnqueueUdpPacket(packet []byte) {
+	l.UDPPackets.Inc()
 	packetCopy := make([]byte, len(packet))
 	copy(packetCopy, packet)
 	l.UdpPacketQueue <- packetCopy
@@ -84,7 +85,6 @@ func (l *StatsDUDPListener) ProcessUdpPacketQueue() {
 }
 
 func (l *StatsDUDPListener) HandlePacket(packet []byte) {
-	l.UDPPackets.Inc()
 	lines := strings.Split(string(packet), "\n")
 	for _, line := range lines {
 		level.Debug(l.Logger).Log("msg", "Incoming line", "proto", "udp", "line", line)

--- a/pkg/listener/listener.go
+++ b/pkg/listener/listener.go
@@ -77,7 +77,6 @@ func (l *StatsDUDPListener) EnqueueUdpPacket(packet []byte) {
 }
 
 func (l *StatsDUDPListener) ProcessUdpPacketQueue() {
-	level.Info(l.Logger).Log("msg", "Running in pipelining mode")
 	for {
 		packet := <-l.UdpPacketQueue
 		l.HandlePacket(packet)

--- a/pkg/listener/listener.go
+++ b/pkg/listener/listener.go
@@ -66,13 +66,14 @@ func (l *StatsDUDPListener) Listen() {
 			level.Error(l.Logger).Log("error", err)
 			return
 		}
-		l.EnqueueUdpPacket(buf[0:n])
+		// avoid making copies of slices since we need to minimize the time spent here in order not to drop packets
+		l.EnqueueUdpPacket(buf, n)
 	}
 }
 
-func (l *StatsDUDPListener) EnqueueUdpPacket(packet []byte) {
+func (l *StatsDUDPListener) EnqueueUdpPacket(packet []byte, n int) {
 	l.UDPPackets.Inc()
-	packetCopy := make([]byte, len(packet))
+	packetCopy := make([]byte, n)
 	copy(packetCopy, packet)
 	l.UdpPacketQueue <- packetCopy
 }


### PR DESCRIPTION
### Summary of this PR
In this PR I am introducing a queue for raw statsd udp payloads and a worker to process them in another goroutine

### Problem
As discussed in https://github.com/grafana/k6/issues/2044, when both number of packets arriving and size of the packets are large, statds_exporter starts to drop UDP packets because processing speed cannot catch the packet arrival speed

### Solution
In the past, I implemented similar UDP packet processing application in Java and best practice was there to read packet in one thread and process packets in another thread(s), therefore I introduced similar logic here: I added a queue / channel (chan []byte) so that the goroutine reading the packets from UDP socket can enqueue them in order to minimize time spent per packet and packets are processed in another goroutine which reads from the queue / channel

### Result
Packet drop rates decreased, most of the time no packet drops occur while in old version packets are always dropped for the case discussed in  https://github.com/grafana/k6/issues/2044

**Before:**
```
$ curl -s http://localhost:9102/metrics | grep udp
statsd_exporter_udp_packets_total 21270
```
`
packets in tcpdump (udp.dstport == 9125) 21477`

_207 packets are dropped_

**After:**
```
$ curl -s http://localhost:9102/metrics | grep udp
statsd_exporter_udp_packets_total 21384
```

`packets in tcpdump (udp.dstport == 9125) 21384`

_No packets are dropped_

**Future TODOs**
Memory benchmarks discussed in https://github.com/prometheus/statsd_exporter/pull/459
