### PR TITLE
Add configuration for keeping original labels in mappings

### DIFF
--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -105,6 +105,10 @@ func (b *Exporter) handleEvent(thisEvent event.Event) {
 		}
 		metricName = mapper.EscapeMetricName(mapping.Name)
 		for label, value := range labels {
+			if _, ok := prometheusLabels[label]; mapping.HonorLabels && ok {
+				continue
+			}
+
 			prometheusLabels[label] = value
 		}
 		b.EventsActions.WithLabelValues(string(mapping.Action)).Inc()

--- a/pkg/mapper/mapping.go
+++ b/pkg/mapper/mapping.go
@@ -28,6 +28,7 @@ type MetricMapping struct {
 	nameFormatter    *fsm.TemplateFormatter
 	regex            *regexp.Regexp
 	Labels           prometheus.Labels `yaml:"labels"`
+	HonorLabels      bool              `yaml:"honor_labels"`
 	labelKeys        []string
 	labelFormatters  []*fsm.TemplateFormatter
 	ObserverType     ObserverType      `yaml:"observer_type"`
@@ -57,6 +58,7 @@ func (m *MetricMapping) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	m.Match = tmp.Match
 	m.Name = tmp.Name
 	m.Labels = tmp.Labels
+	m.HonorLabels = tmp.HonorLabels
 	m.ObserverType = tmp.ObserverType
 	m.LegacyBuckets = tmp.LegacyBuckets
 	m.LegacyQuantiles = tmp.LegacyQuantiles


### PR DESCRIPTION
When a label is assigned in mappings that already exists, it will be replaced. This PR introduces a `honor_labels` parameter. When this parameter is set to true, it will preserve the original value of the label.