### PR TITLE
Add DogStatsD extended aggregation support

### DIFF
--- a/pkg/line/line.go
+++ b/pkg/line/line.go
@@ -217,7 +217,7 @@ func (p *Parser) LineToEvents(line string, sampleErrors prometheus.CounterVec, s
 
 	labels := map[string]string{}
 	metric := p.parseNameAndTags(elements[0], labels, tagErrors, logger)
-	usingDogStatsDTags := strings.Contains(line, "|#")
+	usingDogStatsDTags := strings.Contains(elements[1], "|#")
 	if usingDogStatsDTags && len(labels) > 0 {
 		// using DogStatsD tags
 

--- a/pkg/line/line.go
+++ b/pkg/line/line.go
@@ -217,50 +217,46 @@ func (p *Parser) LineToEvents(line string, sampleErrors prometheus.CounterVec, s
 
 	labels := map[string]string{}
 	metric := p.parseNameAndTags(elements[0], labels, tagErrors, logger)
-
-	var samples []string
-	if strings.Contains(elements[1], "|#") {
+	usingDogStatsDTags := strings.Contains(line, "|#")
+	if usingDogStatsDTags && len(labels) > 0 {
 		// using DogStatsD tags
 
 		// don't allow mixed tagging styles
-		if len(labels) > 0 {
-			sampleErrors.WithLabelValues("mixed_tagging_styles").Inc()
-			level.Debug(logger).Log("msg", "Bad line (multiple tagging styles) from StatsD", "line", line)
+		sampleErrors.WithLabelValues("mixed_tagging_styles").Inc()
+		level.Debug(logger).Log("msg", "Bad line (multiple tagging styles) from StatsD", "line", line)
+		return events
+	}
+
+	var samples []string
+	lineParts := strings.SplitN(elements[1], "|", 3)
+	if strings.Contains(lineParts[0], ":") {
+		// handle DogStatsD extended aggregation
+		isValidAggType := false
+		switch lineParts[1] {
+		case
+			"ms", // timer
+			"h",  // histogram
+			"d":  // distribution
+			isValidAggType = true
+		}
+
+		if isValidAggType {
+			aggValues := strings.Split(lineParts[0], ":")
+			aggLines := make([]string, len(aggValues))
+			_, aggLineSuffix, _ := strings.Cut(elements[1], "|")
+
+			for i, aggValue := range aggValues {
+				aggLines[i] = strings.Join([]string{aggValue, aggLineSuffix}, "|")
+			}
+			samples = aggLines
+		} else {
+			sampleErrors.WithLabelValues("invalid_extended_aggregate_type").Inc()
+			level.Debug(logger).Log("msg", "Bad line (invalid extended aggregate type) from StatsD", "line", line)
 			return events
 		}
-
-		lineParts := strings.SplitN(elements[1], "|", 3)
-		if strings.Contains(lineParts[0], ":") {
-			// handle DogStatsD extended aggregation
-			var isValidAggType bool
-			switch lineParts[1] {
-			case
-				"ms", // timer
-				"h",  // histogram
-				"d":  // distribution
-				isValidAggType = true
-			default:
-				isValidAggType = false
-			}
-
-			if isValidAggType {
-				aggValues := strings.Split(lineParts[0], ":")
-				aggLines := make([]string, len(aggValues))
-
-				for i, aggValue := range aggValues {
-					aggLines[i] = strings.Join([]string{aggValue, lineParts[1], lineParts[2]}, "|")
-				}
-
-				samples = aggLines
-			} else {
-				sampleErrors.WithLabelValues("invalid_extended_aggregate_type").Inc()
-				level.Debug(logger).Log("msg", "Bad line (invalid extended aggregate type) from StatsD", "line", line)
-				return events
-			}
-		} else {
-			// disable multi-metrics
-			samples = elements[1:]
-		}
+	} else if usingDogStatsDTags {
+		// disable multi-metrics
+		samples = elements[1:]
 	} else {
 		samples = strings.Split(elements[1], ":")
 	}

--- a/pkg/line/line.go
+++ b/pkg/line/line.go
@@ -229,8 +229,21 @@ func (p *Parser) LineToEvents(line string, sampleErrors prometheus.CounterVec, s
 			return events
 		}
 
-		// disable multi-metrics
-		samples = elements[1:]
+		// handle DogStatsD extended aggregation
+		lineParts := strings.SplitN(elements[1], "|", 2)
+		if strings.Contains(lineParts[0], ":") {
+			aggValues := strings.Split(lineParts[0], ":")
+			aggLines := make([]string, len(aggValues))
+			tags := lineParts[1]
+
+			for i, aggValue := range aggValues {
+				aggLines[i] = strings.Join([]string{aggValue, tags}, "|")
+			}
+			samples = aggLines
+		} else {
+			// disable multi-metrics
+			samples = elements[1:]
+		}
 	} else {
 		samples = strings.Split(elements[1], ":")
 	}

--- a/pkg/line/line_test.go
+++ b/pkg/line/line_test.go
@@ -679,6 +679,18 @@ func TestLineToEvents(t *testing.T) {
 		"datadog gauge with invalid extended aggregation values": {
 			in: "foo_gauge:0.5:120:3000:10:20000:0.01|g|#tag1:bar,tag2:baz",
 		},
+		"datadog timing with extended aggregation values and invalid signalfx tags": {
+			in: "foo.[tag1=bar,tag2=baz]test:0.5:120:3000:10:20000:0.01|ms",
+		},
+		"SignalFX counter with invalid Datadog style extended aggregation values": {
+			in: "foo.[tag1=bar,tag2=baz]test:0.5:120:3000:10:20000:0.01|c",
+		},
+		"SignalFX no tags counter with invalid Datadog style extended aggregation values": {
+			in: "foo.[]test:0.5:120:3000:10:20000:0.01|c",
+		},
+		"SignalFX no tags with invalid Datadog style extended aggregation values and timings type": {
+			in: "foo.[]test:0.5:120:3000:10:20000:0.01|ms",
+		},
 		"timings with sampling factor": {
 			in: "foo.timing:0.5|ms|@0.1",
 			out: event.Events{

--- a/pkg/line/line_test.go
+++ b/pkg/line/line_test.go
@@ -414,6 +414,34 @@ func TestLineToEvents(t *testing.T) {
 				&event.ObserverEvent{OMetricName: "foo_timing", OValue: 0.00001, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
 			},
 		},
+		"datadog histogram with extended aggregation values": {
+			in: "foo_histogram:0.5:120:3000:10:20000:0.01|h|#tag1:bar,#tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{OMetricName: "foo_histogram", OValue: 0.5, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
+				&event.ObserverEvent{OMetricName: "foo_histogram", OValue: 120, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
+				&event.ObserverEvent{OMetricName: "foo_histogram", OValue: 3000, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
+				&event.ObserverEvent{OMetricName: "foo_histogram", OValue: 10, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
+				&event.ObserverEvent{OMetricName: "foo_histogram", OValue: 20000, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
+				&event.ObserverEvent{OMetricName: "foo_histogram", OValue: 0.01, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
+			},
+		},
+		"datadog distribution with extended aggregation values": {
+			in: "foo_distribution:0.5:120:3000:10:20000:0.01|d|#tag1:bar,#tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{OMetricName: "foo_distribution", OValue: 0.5, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
+				&event.ObserverEvent{OMetricName: "foo_distribution", OValue: 120, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
+				&event.ObserverEvent{OMetricName: "foo_distribution", OValue: 3000, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
+				&event.ObserverEvent{OMetricName: "foo_distribution", OValue: 10, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
+				&event.ObserverEvent{OMetricName: "foo_distribution", OValue: 20000, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
+				&event.ObserverEvent{OMetricName: "foo_distribution", OValue: 0.01, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
+			},
+		},
+		"datadog counter with invalid extended aggregation values": {
+			in: "foo_counter:0.5:120:3000:10:20000:0.01|c|#tag1:bar,#tag2:baz",
+		},
+		"datadog gauge with invalid extended aggregation values": {
+			in: "foo_gauge:0.5:120:3000:10:20000:0.01|g|#tag1:bar,#tag2:baz",
+		},
 		"timings with sampling factor": {
 			in: "foo.timing:0.5|ms|@0.1",
 			out: event.Events{

--- a/pkg/line/line_test.go
+++ b/pkg/line/line_test.go
@@ -691,6 +691,12 @@ func TestLineToEvents(t *testing.T) {
 		"SignalFX no tags with invalid Datadog style extended aggregation values and timings type": {
 			in: "foo.[]test:0.5:120:3000:10:20000:0.01|ms",
 		},
+		"Influx no tags with invalid Datadog style extended aggregation values and timings type": {
+			in: "foo.test:0.5:120:3000:10:20000:0.01|ms",
+		},
+		"Influx no tags with invalid Datadog style extended aggregation values and histogram type": {
+			in: "foo.test:0.5:120:3000:10:20000:0.01|ms",
+		},
 		"timings with sampling factor": {
 			in: "foo.timing:0.5|ms|@0.1",
 			out: event.Events{

--- a/pkg/line/line_test.go
+++ b/pkg/line/line_test.go
@@ -404,57 +404,334 @@ func TestLineToEvents(t *testing.T) {
 			in: "foo:100|c|@0.1|#tag1:valid,tag2:\xc3\x28invalid",
 		},
 		"datadog timings with extended aggregation values": {
-			in: "foo_timing:0.5:120:3000:10:20000:0.01|ms|#tag1:bar,#tag2:baz",
+			in: "foo_timing:0.5:120:3000:10:20000:0.01|ms|#tag1:bar,tag2:baz",
 			out: event.Events{
-				&event.ObserverEvent{OMetricName: "foo_timing", OValue: 0.0005, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
-				&event.ObserverEvent{OMetricName: "foo_timing", OValue: 0.120, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
-				&event.ObserverEvent{OMetricName: "foo_timing", OValue: 3, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
-				&event.ObserverEvent{OMetricName: "foo_timing", OValue: 0.01, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
-				&event.ObserverEvent{OMetricName: "foo_timing", OValue: 20, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
-				&event.ObserverEvent{OMetricName: "foo_timing", OValue: 0.00001, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
 			},
 		},
-		"datadog histogram with extended aggregation values": {
-			in: "foo_histogram:0.5:120:3000:10:20000:0.01|h|#tag1:bar,#tag2:baz",
+		"datadog timings with extended aggregation values without tags": {
+			in: "foo_timing:0.5:120:3000:10:20000:0.01|ms",
 			out: event.Events{
-				&event.ObserverEvent{OMetricName: "foo_histogram", OValue: 0.5, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
-				&event.ObserverEvent{OMetricName: "foo_histogram", OValue: 120, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
-				&event.ObserverEvent{OMetricName: "foo_histogram", OValue: 3000, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
-				&event.ObserverEvent{OMetricName: "foo_histogram", OValue: 10, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
-				&event.ObserverEvent{OMetricName: "foo_histogram", OValue: 20000, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
-				&event.ObserverEvent{OMetricName: "foo_histogram", OValue: 0.01, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog timings with extended aggregation values and sampling but without tags": {
+			in: "foo_timing:0.5:120:3000:10:20000:0.01|ms|@0.5",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog timings with extended aggregation values, sampling, and tags": {
+			in: "foo_timing:0.5:120:3000:10:20000:0.01|ms|@0.5|#tag1:bar,tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		},
+		"datadog histogram with extended aggregation values and tags": {
+			in: "foo_histogram:0.5:120:3000:10:20000:0.01|h|#tag1:bar,tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      0.5,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      120,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      3000,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      10,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      20000,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
 			},
 		},
 		"datadog distribution with extended aggregation values": {
-			in: "foo_distribution:0.5:120:3000:10:20000:0.01|d|#tag1:bar,#tag2:baz",
+			in: "foo_distribution:0.5:120:3000:10:20000:0.01|d|#tag1:bar,tag2:baz",
 			out: event.Events{
-				&event.ObserverEvent{OMetricName: "foo_distribution", OValue: 0.5, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
-				&event.ObserverEvent{OMetricName: "foo_distribution", OValue: 120, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
-				&event.ObserverEvent{OMetricName: "foo_distribution", OValue: 3000, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
-				&event.ObserverEvent{OMetricName: "foo_distribution", OValue: 10, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
-				&event.ObserverEvent{OMetricName: "foo_distribution", OValue: 20000, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
-				&event.ObserverEvent{OMetricName: "foo_distribution", OValue: 0.01, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      0.5,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      120,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      3000,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      10,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      20000,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
 			},
 		},
 		"datadog counter with invalid extended aggregation values": {
-			in: "foo_counter:0.5:120:3000:10:20000:0.01|c|#tag1:bar,#tag2:baz",
+			in: "foo_counter:0.5:120:3000:10:20000:0.01|c|#tag1:bar,tag2:baz",
 		},
 		"datadog gauge with invalid extended aggregation values": {
-			in: "foo_gauge:0.5:120:3000:10:20000:0.01|g|#tag1:bar,#tag2:baz",
+			in: "foo_gauge:0.5:120:3000:10:20000:0.01|g|#tag1:bar,tag2:baz",
 		},
 		"timings with sampling factor": {
 			in: "foo.timing:0.5|ms|@0.1",
 			out: event.Events{
-				&event.ObserverEvent{OMetricName: "foo.timing", OValue: 0.0005, OLabels: map[string]string{}},
-				&event.ObserverEvent{OMetricName: "foo.timing", OValue: 0.0005, OLabels: map[string]string{}},
-				&event.ObserverEvent{OMetricName: "foo.timing", OValue: 0.0005, OLabels: map[string]string{}},
-				&event.ObserverEvent{OMetricName: "foo.timing", OValue: 0.0005, OLabels: map[string]string{}},
-				&event.ObserverEvent{OMetricName: "foo.timing", OValue: 0.0005, OLabels: map[string]string{}},
-				&event.ObserverEvent{OMetricName: "foo.timing", OValue: 0.0005, OLabels: map[string]string{}},
-				&event.ObserverEvent{OMetricName: "foo.timing", OValue: 0.0005, OLabels: map[string]string{}},
-				&event.ObserverEvent{OMetricName: "foo.timing", OValue: 0.0005, OLabels: map[string]string{}},
-				&event.ObserverEvent{OMetricName: "foo.timing", OValue: 0.0005, OLabels: map[string]string{}},
-				&event.ObserverEvent{OMetricName: "foo.timing", OValue: 0.0005, OLabels: map[string]string{}},
+				&event.ObserverEvent{
+					OMetricName: "foo.timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo.timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo.timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo.timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo.timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo.timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo.timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo.timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo.timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo.timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
 			},
 		},
 		"bad line": {

--- a/pkg/line/line_test.go
+++ b/pkg/line/line_test.go
@@ -1031,6 +1031,300 @@ func TestDisableParsingLineToEvents(t *testing.T) {
 				},
 			},
 		},
+		"datadog timings with extended aggregation values": {
+			in: "foo_timing:0.5:120:3000:10:20000:0.01|ms|#tag1:bar,tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog timings with extended aggregation values without tags": {
+			in: "foo_timing:0.5:120:3000:10:20000:0.01|ms",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog timings with extended aggregation values and sampling but without tags": {
+			in: "foo_timing:0.5:120:3000:10:20000:0.01|ms|@0.5",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog timings with extended aggregation values, sampling, and tags": {
+			in: "foo_timing:0.5:120:3000:10:20000:0.01|ms|@0.5|#tag1:bar,tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog histogram with extended aggregation values and tags": {
+			in: "foo_histogram:0.5:120:3000:10:20000:0.01|h|#tag1:bar,tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      0.5,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      3000,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      10,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      20000,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog distribution with extended aggregation values": {
+			in: "foo_distribution:0.5:120:3000:10:20000:0.01|d|#tag1:bar,tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      0.5,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      3000,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      10,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      20000,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog counter with invalid extended aggregation values": {
+			in: "foo_counter:0.5:120:3000:10:20000:0.01|c|#tag1:bar,tag2:baz",
+		},
+		"datadog gauge with invalid extended aggregation values": {
+			in: "foo_gauge:0.5:120:3000:10:20000:0.01|g|#tag1:bar,tag2:baz",
+		},
+		"datadog timing with extended aggregation values and invalid signalfx tags": {
+			in: "foo.[tag1=bar,tag2=baz]test:0.5:120:3000:10:20000:0.01|ms",
+		},
+		"SignalFX counter with invalid Datadog style extended aggregation values": {
+			in: "foo.[tag1=bar,tag2=baz]test:0.5:120:3000:10:20000:0.01|c",
+		},
+		"SignalFX no tags counter with invalid Datadog style extended aggregation values": {
+			in: "foo.[]test:0.5:120:3000:10:20000:0.01|c",
+		},
+		"SignalFX no tags with invalid Datadog style extended aggregation values and timings type": {
+			in: "foo.[]test:0.5:120:3000:10:20000:0.01|ms",
+		},
+		"Influx no tags with invalid Datadog style extended aggregation values and timings type": {
+			in: "foo.test:0.5:120:3000:10:20000:0.01|ms",
+		},
+		"Influx no tags with invalid Datadog style extended aggregation values and histogram type": {
+			in: "foo.test:0.5:120:3000:10:20000:0.01|ms",
+		},
 		"librato/dogstatsd mixed tag styles without sampling": {
 			in:  "foo#tag1=foo,tag3=bing:100|c|#tag1:bar,#tag2:baz",
 			out: event.Events{},
@@ -1266,6 +1560,300 @@ func TestDisableParsingDogstatsdLineToEvents(t *testing.T) {
 					CLabels:     map[string]string{},
 				},
 			},
+		},
+		"datadog timings with extended aggregation values": {
+			in: "foo_timing:0.5:120:3000:10:20000:0.01|ms|#tag1:bar,tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog timings with extended aggregation values without tags": {
+			in: "foo_timing:0.5:120:3000:10:20000:0.01|ms",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog timings with extended aggregation values and sampling but without tags": {
+			in: "foo_timing:0.5:120:3000:10:20000:0.01|ms|@0.5",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog timings with extended aggregation values, sampling, and tags": {
+			in: "foo_timing:0.5:120:3000:10:20000:0.01|ms|@0.5|#tag1:bar,tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog histogram with extended aggregation values and tags": {
+			in: "foo_histogram:0.5:120:3000:10:20000:0.01|h|#tag1:bar,tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      0.5,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      3000,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      10,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      20000,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog distribution with extended aggregation values": {
+			in: "foo_distribution:0.5:120:3000:10:20000:0.01|d|#tag1:bar,tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      0.5,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      3000,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      10,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      20000,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog counter with invalid extended aggregation values": {
+			in: "foo_counter:0.5:120:3000:10:20000:0.01|c|#tag1:bar,tag2:baz",
+		},
+		"datadog gauge with invalid extended aggregation values": {
+			in: "foo_gauge:0.5:120:3000:10:20000:0.01|g|#tag1:bar,tag2:baz",
+		},
+		"datadog timing with extended aggregation values and invalid signalfx tags": {
+			in: "foo.[tag1=bar,tag2=baz]test:0.5:120:3000:10:20000:0.01|ms",
+		},
+		"SignalFX counter with invalid Datadog style extended aggregation values": {
+			in: "foo.[tag1=bar,tag2=baz]test:0.5:120:3000:10:20000:0.01|c",
+		},
+		"SignalFX no tags counter with invalid Datadog style extended aggregation values": {
+			in: "foo.[]test:0.5:120:3000:10:20000:0.01|c",
+		},
+		"SignalFX no tags with invalid Datadog style extended aggregation values and timings type": {
+			in: "foo.[]test:0.5:120:3000:10:20000:0.01|ms",
+		},
+		"Influx no tags with invalid Datadog style extended aggregation values and timings type": {
+			in: "foo.test:0.5:120:3000:10:20000:0.01|ms",
+		},
+		"Influx no tags with invalid Datadog style extended aggregation values and histogram type": {
+			in: "foo.test:0.5:120:3000:10:20000:0.01|ms",
 		},
 		"librato/dogstatsd mixed tag styles without sampling": {
 			in:  "foo#tag1=foo,tag3=bing:100|c|#tag1:bar,#tag2:baz",
@@ -1506,6 +2094,300 @@ func TestDisableParsingInfluxdbLineToEvents(t *testing.T) {
 				},
 			},
 		},
+		"datadog timings with extended aggregation values": {
+			in: "foo_timing:0.5:120:3000:10:20000:0.01|ms|#tag1:bar,tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		},
+		"datadog timings with extended aggregation values without tags": {
+			in: "foo_timing:0.5:120:3000:10:20000:0.01|ms",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog timings with extended aggregation values and sampling but without tags": {
+			in: "foo_timing:0.5:120:3000:10:20000:0.01|ms|@0.5",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog timings with extended aggregation values, sampling, and tags": {
+			in: "foo_timing:0.5:120:3000:10:20000:0.01|ms|@0.5|#tag1:bar,tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		},
+		"datadog histogram with extended aggregation values and tags": {
+			in: "foo_histogram:0.5:120:3000:10:20000:0.01|h|#tag1:bar,tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      0.5,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      120,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      3000,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      10,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      20000,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		},
+		"datadog distribution with extended aggregation values": {
+			in: "foo_distribution:0.5:120:3000:10:20000:0.01|d|#tag1:bar,tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      0.5,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      120,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      3000,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      10,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      20000,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		},
+		"datadog counter with invalid extended aggregation values": {
+			in: "foo_counter:0.5:120:3000:10:20000:0.01|c|#tag1:bar,tag2:baz",
+		},
+		"datadog gauge with invalid extended aggregation values": {
+			in: "foo_gauge:0.5:120:3000:10:20000:0.01|g|#tag1:bar,tag2:baz",
+		},
+		"datadog timing with extended aggregation values and invalid signalfx tags": {
+			in: "foo.[tag1=bar,tag2=baz]test:0.5:120:3000:10:20000:0.01|ms",
+		},
+		"SignalFX counter with invalid Datadog style extended aggregation values": {
+			in: "foo.[tag1=bar,tag2=baz]test:0.5:120:3000:10:20000:0.01|c",
+		},
+		"SignalFX no tags counter with invalid Datadog style extended aggregation values": {
+			in: "foo.[]test:0.5:120:3000:10:20000:0.01|c",
+		},
+		"SignalFX no tags with invalid Datadog style extended aggregation values and timings type": {
+			in: "foo.[]test:0.5:120:3000:10:20000:0.01|ms",
+		},
+		"Influx no tags with invalid Datadog style extended aggregation values and timings type": {
+			in: "foo.test:0.5:120:3000:10:20000:0.01|ms",
+		},
+		"Influx no tags with invalid Datadog style extended aggregation values and histogram type": {
+			in: "foo.test:0.5:120:3000:10:20000:0.01|ms",
+		},
 		"librato/dogstatsd mixed tag styles without sampling": {
 			in:  "foo#tag1=foo,tag3=bing:100|c|#tag1:bar,#tag2:baz",
 			out: event.Events{},
@@ -1745,6 +2627,300 @@ func TestDisableParsingSignalfxLineToEvents(t *testing.T) {
 				},
 			},
 		},
+		"datadog timings with extended aggregation values": {
+			in: "foo_timing:0.5:120:3000:10:20000:0.01|ms|#tag1:bar,tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		},
+		"datadog timings with extended aggregation values without tags": {
+			in: "foo_timing:0.5:120:3000:10:20000:0.01|ms",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog timings with extended aggregation values and sampling but without tags": {
+			in: "foo_timing:0.5:120:3000:10:20000:0.01|ms|@0.5",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog timings with extended aggregation values, sampling, and tags": {
+			in: "foo_timing:0.5:120:3000:10:20000:0.01|ms|@0.5|#tag1:bar,tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		},
+		"datadog histogram with extended aggregation values and tags": {
+			in: "foo_histogram:0.5:120:3000:10:20000:0.01|h|#tag1:bar,tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      0.5,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      120,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      3000,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      10,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      20000,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		},
+		"datadog distribution with extended aggregation values": {
+			in: "foo_distribution:0.5:120:3000:10:20000:0.01|d|#tag1:bar,tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      0.5,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      120,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      3000,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      10,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      20000,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		},
+		"datadog counter with invalid extended aggregation values": {
+			in: "foo_counter:0.5:120:3000:10:20000:0.01|c|#tag1:bar,tag2:baz",
+		},
+		"datadog gauge with invalid extended aggregation values": {
+			in: "foo_gauge:0.5:120:3000:10:20000:0.01|g|#tag1:bar,tag2:baz",
+		},
+		"datadog timing with extended aggregation values and invalid signalfx tags": {
+			in: "foo.[tag1=bar,tag2=baz]test:0.5:120:3000:10:20000:0.01|ms",
+		},
+		"SignalFX counter with invalid Datadog style extended aggregation values": {
+			in: "foo.[tag1=bar,tag2=baz]test:0.5:120:3000:10:20000:0.01|c",
+		},
+		"SignalFX no tags counter with invalid Datadog style extended aggregation values": {
+			in: "foo.[]test:0.5:120:3000:10:20000:0.01|c",
+		},
+		"SignalFX no tags with invalid Datadog style extended aggregation values and timings type": {
+			in: "foo.[]test:0.5:120:3000:10:20000:0.01|ms",
+		},
+		"Influx no tags with invalid Datadog style extended aggregation values and timings type": {
+			in: "foo.test:0.5:120:3000:10:20000:0.01|ms",
+		},
+		"Influx no tags with invalid Datadog style extended aggregation values and histogram type": {
+			in: "foo.test:0.5:120:3000:10:20000:0.01|ms",
+		},
 		"librato/dogstatsd mixed tag styles without sampling": {
 			in:  "foo#tag1=foo,tag3=bing:100|c|#tag1:bar,#tag2:baz",
 			out: event.Events{},
@@ -1983,6 +3159,300 @@ func TestDisableParsingLibratoLineToEvents(t *testing.T) {
 					CLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
 				},
 			},
+		},
+		"datadog timings with extended aggregation values": {
+			in: "foo_timing:0.5:120:3000:10:20000:0.01|ms|#tag1:bar,tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		},
+		"datadog timings with extended aggregation values without tags": {
+			in: "foo_timing:0.5:120:3000:10:20000:0.01|ms",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog timings with extended aggregation values and sampling but without tags": {
+			in: "foo_timing:0.5:120:3000:10:20000:0.01|ms|@0.5",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{},
+				},
+			},
+		},
+		"datadog timings with extended aggregation values, sampling, and tags": {
+			in: "foo_timing:0.5:120:3000:10:20000:0.01|ms|@0.5|#tag1:bar,tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.0005,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.120,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      3,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      20,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_timing",
+					OValue:      0.00001,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		},
+		"datadog histogram with extended aggregation values and tags": {
+			in: "foo_histogram:0.5:120:3000:10:20000:0.01|h|#tag1:bar,tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      0.5,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      120,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      3000,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      10,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      20000,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_histogram",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		},
+		"datadog distribution with extended aggregation values": {
+			in: "foo_distribution:0.5:120:3000:10:20000:0.01|d|#tag1:bar,tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      0.5,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      120,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      3000,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      10,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      20000,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+				&event.ObserverEvent{
+					OMetricName: "foo_distribution",
+					OValue:      0.01,
+					OLabels:     map[string]string{"tag1": "bar", "tag2": "baz"},
+				},
+			},
+		},
+		"datadog counter with invalid extended aggregation values": {
+			in: "foo_counter:0.5:120:3000:10:20000:0.01|c|#tag1:bar,tag2:baz",
+		},
+		"datadog gauge with invalid extended aggregation values": {
+			in: "foo_gauge:0.5:120:3000:10:20000:0.01|g|#tag1:bar,tag2:baz",
+		},
+		"datadog timing with extended aggregation values and invalid signalfx tags": {
+			in: "foo.[tag1=bar,tag2=baz]test:0.5:120:3000:10:20000:0.01|ms",
+		},
+		"SignalFX counter with invalid Datadog style extended aggregation values": {
+			in: "foo.[tag1=bar,tag2=baz]test:0.5:120:3000:10:20000:0.01|c",
+		},
+		"SignalFX no tags counter with invalid Datadog style extended aggregation values": {
+			in: "foo.[]test:0.5:120:3000:10:20000:0.01|c",
+		},
+		"SignalFX no tags with invalid Datadog style extended aggregation values and timings type": {
+			in: "foo.[]test:0.5:120:3000:10:20000:0.01|ms",
+		},
+		"Influx no tags with invalid Datadog style extended aggregation values and timings type": {
+			in: "foo.test:0.5:120:3000:10:20000:0.01|ms",
+		},
+		"Influx no tags with invalid Datadog style extended aggregation values and histogram type": {
+			in: "foo.test:0.5:120:3000:10:20000:0.01|ms",
 		},
 		"librato/dogstatsd mixed tag styles without sampling": {
 			in:  "foo#tag1=foo,tag3=bing:100|c|#tag1:bar,#tag2:baz",

--- a/pkg/line/line_test.go
+++ b/pkg/line/line_test.go
@@ -403,6 +403,17 @@ func TestLineToEvents(t *testing.T) {
 		"datadog tag extension with both valid and invalid utf8 tag values": {
 			in: "foo:100|c|@0.1|#tag1:valid,tag2:\xc3\x28invalid",
 		},
+		"datadog timings with extended aggregation values": {
+			in: "foo_timing:0.5:120:3000:10:20000:0.01|ms|#tag1:bar,#tag2:baz",
+			out: event.Events{
+				&event.ObserverEvent{OMetricName: "foo_timing", OValue: 0.0005, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
+				&event.ObserverEvent{OMetricName: "foo_timing", OValue: 0.120, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
+				&event.ObserverEvent{OMetricName: "foo_timing", OValue: 3, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
+				&event.ObserverEvent{OMetricName: "foo_timing", OValue: 0.01, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
+				&event.ObserverEvent{OMetricName: "foo_timing", OValue: 20, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
+				&event.ObserverEvent{OMetricName: "foo_timing", OValue: 0.00001, OLabels: map[string]string{"tag1": "bar", "tag2": "baz"}},
+			},
+		},
 		"timings with sampling factor": {
 			in: "foo.timing:0.5|ms|@0.1",
 			out: event.Events{


### PR DESCRIPTION
This PR aims to add the ability for statsd exporter to receive [DogStatsD extended aggregation metrics](https://github.com/DataDog/datadog-go?tab=readme-ov-file#extended-aggregation). It is a feature I requested in Issue #557 and I wanted to try to implement it myself following the in-issue commented advice from @glightfoot. 

### Summary of Implementation

When DogStatsD has extended aggregation enabled, instead of sending:

```
my_distribution_metric:21|d|#all,my,tags
my_distribution_metric:43.2|d|#all,my,tags
my_distribution_metric:1657|d|#all,my,tags
```

it sends

```
my_distribution_metric:21:43.2:1657|d|#all,my,tags
```

This PR updates the `LineToEvents` function in the specific case of more than one `:` left of the initial `|`. If so, assume it is an extended aggregation line, convert it back into its multi-line non-aggregated form, then pass it onto the rest of the function as the samples. The logic enforces that this form of aggregation metrics must be only of the types of distribution, histogram, or timing.

