### PR TITLE
Enable all govet linters except fieldalignment

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,9 @@ linters:
     - whitespace
 linters-settings:
   govet:
-    check-shadowing: true
+    enable-all: true
+    disable:
+      - fieldalignment
 issues:
   exclude-use-default: false
   exclude:


### PR DESCRIPTION
When linting, govet complains about the deprecated `check-shadowing` setting.
Replace it with enabling all currently passing linters. This excludes only
`fieldalignment`.