### PR TITLE
feat(event): Add MultiValueEvent interface and MultiObserverEvent implementation

### DIFF
--- a/pkg/event/event_test.go
+++ b/pkg/event/event_test.go
@@ -14,11 +14,13 @@
 package event
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/statsd_exporter/pkg/clock"
+	"github.com/prometheus/statsd_exporter/pkg/mapper"
 )
 
 var eventsFlushed = prometheus.NewCounter(
@@ -83,5 +85,194 @@ func TestEventIntervalFlush(t *testing.T) {
 
 	if len(events) != 10 {
 		t.Fatal("Expected 10 events in the event channel, but got", len(events))
+	}
+}
+
+func TestMultiValueEvent(t *testing.T) {
+	tests := []struct {
+		name       string
+		event      MultiValueEvent
+		wantValues []float64
+		wantName   string
+		wantType   mapper.MetricType
+		wantLabels map[string]string
+	}{
+		{
+			name: "MultiObserverEvent with single value",
+			event: &MultiObserverEvent{
+				OMetricName: "test_metric",
+				OValues:     []float64{1.0},
+				OLabels:     map[string]string{"label": "value"},
+				SampleRate:  0,
+			},
+			wantValues: []float64{1.0},
+			wantName:   "test_metric",
+			wantType:   mapper.MetricTypeObserver,
+			wantLabels: map[string]string{"label": "value"},
+		},
+		{
+			name: "MultiObserverEvent with multiple values",
+			event: &MultiObserverEvent{
+				OMetricName: "test_metric",
+				OValues:     []float64{1.0, 2.0, 3.0},
+				OLabels:     map[string]string{"label": "value"},
+				SampleRate:  0.5,
+			},
+			wantValues: []float64{1.0, 2.0, 3.0},
+			wantName:   "test_metric",
+			wantType:   mapper.MetricTypeObserver,
+			wantLabels: map[string]string{"label": "value"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.event.Values(); !reflect.DeepEqual(got, tt.wantValues) {
+				t.Errorf("MultiValueEvent.Values() = %v, want %v", got, tt.wantValues)
+			}
+			if got := tt.event.MetricName(); got != tt.wantName {
+				t.Errorf("MultiValueEvent.MetricName() = %v, want %v", got, tt.wantName)
+			}
+			if got := tt.event.MetricType(); got != tt.wantType {
+				t.Errorf("MultiValueEvent.MetricType() = %v, want %v", got, tt.wantType)
+			}
+			if got := tt.event.Labels(); !reflect.DeepEqual(got, tt.wantLabels) {
+				t.Errorf("MultiValueEvent.Labels() = %v, want %v", got, tt.wantLabels)
+			}
+			if got := tt.event.Value(); got != tt.wantValues[0] {
+				t.Errorf("MultiValueEvent.Value() = %v, want %v", got, tt.wantValues[0])
+			}
+		})
+	}
+}
+
+func TestMultiObserverEvent_Explode(t *testing.T) {
+	tests := []struct {
+		name       string
+		event      *MultiObserverEvent
+		wantEvents []Event
+	}{
+		{
+			name: "single value no sampling",
+			event: &MultiObserverEvent{
+				OMetricName: "test_metric",
+				OValues:     []float64{1.0},
+				OLabels:     map[string]string{"label": "value"},
+				SampleRate:  0,
+			},
+			wantEvents: []Event{
+				&MultiObserverEvent{
+					OMetricName: "test_metric",
+					OValues:     []float64{1.0},
+					OLabels:     map[string]string{"label": "value"},
+					SampleRate:  0,
+				},
+			},
+		},
+		{
+			name: "multiple values no sampling",
+			event: &MultiObserverEvent{
+				OMetricName: "test_metric",
+				OValues:     []float64{1.0, 2.0, 3.0},
+				OLabels:     map[string]string{"label": "value"},
+				SampleRate:  0,
+			},
+			wantEvents: []Event{
+				&ObserverEvent{
+					OMetricName: "test_metric",
+					OValue:      1.0,
+					OLabels:     map[string]string{"label": "value"},
+				},
+				&ObserverEvent{
+					OMetricName: "test_metric",
+					OValue:      2.0,
+					OLabels:     map[string]string{"label": "value"},
+				},
+				&ObserverEvent{
+					OMetricName: "test_metric",
+					OValue:      3.0,
+					OLabels:     map[string]string{"label": "value"},
+				},
+			},
+		},
+		{
+			name: "multiple values with sampling",
+			event: &MultiObserverEvent{
+				OMetricName: "test_metric",
+				OValues:     []float64{1.0, 2.0},
+				OLabels:     map[string]string{"label": "value"},
+				SampleRate:  0.5,
+			},
+			wantEvents: []Event{
+				&ObserverEvent{
+					OMetricName: "test_metric",
+					OValue:      1.0,
+					OLabels:     map[string]string{"label": "value"},
+				},
+				&ObserverEvent{
+					OMetricName: "test_metric",
+					OValue:      2.0,
+					OLabels:     map[string]string{"label": "value"},
+				},
+				&ObserverEvent{
+					OMetricName: "test_metric",
+					OValue:      1.0,
+					OLabels:     map[string]string{"label": "value"},
+				},
+				&ObserverEvent{
+					OMetricName: "test_metric",
+					OValue:      2.0,
+					OLabels:     map[string]string{"label": "value"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.event.Explode()
+			if !reflect.DeepEqual(got, tt.wantEvents) {
+				t.Errorf("MultiObserverEvent.Explode() = %v, want %v", got, tt.wantEvents)
+			}
+		})
+	}
+}
+
+func TestEventImplementations(t *testing.T) {
+	tests := []struct {
+		name  string
+		event interface{}
+	}{
+		{
+			name:  "MultiObserverEvent implements MultiValueEvent",
+			event: &MultiObserverEvent{},
+		},
+		{
+			name:  "MultiObserverEvent implements ExplodableEvent",
+			event: &MultiObserverEvent{},
+		},
+		{
+			name:  "MultiObserverEvent implements Event",
+			event: &MultiObserverEvent{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			switch tt.name {
+			case "MultiObserverEvent implements MultiValueEvent":
+				if _, ok := tt.event.(MultiValueEvent); !ok {
+					t.Error("MultiObserverEvent does not implement MultiValueEvent")
+				}
+			case "MultiObserverEvent implements ExplodableEvent":
+				if _, ok := tt.event.(ExplodableEvent); !ok {
+					t.Error("MultiObserverEvent does not implement ExplodableEvent")
+				}
+			case "MultiObserverEvent implements Event":
+				if _, ok := tt.event.(Event); !ok {
+					t.Error("MultiObserverEvent does not implement Event")
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
This PR introduces the first step in refactoring the event handling system to better
support multiple values in a single event, which will help reduce allocations when
processing events. This is part of a larger effort to improve performance and reduce
memory allocations in the statsd exporter.

Changes:
- Add new `MultiValueEvent` interface that supports multiple values per event
- Add `MultiObserverEvent` implementation for handling multiple observations
- Add `ExplodableEvent` interface for backward compatibility
- Add `Values()` method to existing event types
- Add comprehensive tests for new interfaces and implementations

This change is the foundation for future improvements that will:
1. Move explosion logic to a dedicated package
2. Update the line parser to use multi-value events
3. Modify the exporter to handle multi-value events directly
4. Eventually remove the need for event explosion

The changes in this PR are backward compatible and don't affect existing functionality.

Relates to #577
