### PR TITLE
Keep track of metric names on the metric statsd_exporter_events_conflict_total

### DIFF
--- a/main.go
+++ b/main.go
@@ -148,7 +148,7 @@ var (
 			Name: "statsd_exporter_events_conflict_total",
 			Help: "The total number of StatsD events with conflicting names.",
 		},
-		[]string{"type"},
+		[]string{"type", "metric_name"},
 	)
 	errorEventStats = promauto.NewCounterVec(
 		prometheus.CounterOpts{

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -137,7 +137,7 @@ func (b *Exporter) handleEvent(thisEvent event.Event) {
 			b.EventStats.WithLabelValues("counter").Inc()
 		} else {
 			b.Logger.Debug(regErrF, "metric", metricName, "error", err)
-			b.ConflictingEventStats.WithLabelValues("counter").Inc()
+			b.ConflictingEventStats.WithLabelValues("counter", metricName).Inc()
 		}
 
 	case *event.GaugeEvent:
@@ -152,7 +152,7 @@ func (b *Exporter) handleEvent(thisEvent event.Event) {
 			b.EventStats.WithLabelValues("gauge").Inc()
 		} else {
 			b.Logger.Debug(regErrF, "metric", metricName, "error", err)
-			b.ConflictingEventStats.WithLabelValues("gauge").Inc()
+			b.ConflictingEventStats.WithLabelValues("gauge", metricName).Inc()
 		}
 
 	case *event.ObserverEvent:
@@ -172,7 +172,7 @@ func (b *Exporter) handleEvent(thisEvent event.Event) {
 				b.EventStats.WithLabelValues("observer").Inc()
 			} else {
 				b.Logger.Debug(regErrF, "metric", metricName, "error", err)
-				b.ConflictingEventStats.WithLabelValues("observer").Inc()
+				b.ConflictingEventStats.WithLabelValues("observer", metricName).Inc()
 			}
 
 		case mapper.ObserverTypeDefault, mapper.ObserverTypeSummary:
@@ -182,7 +182,7 @@ func (b *Exporter) handleEvent(thisEvent event.Event) {
 				b.EventStats.WithLabelValues("observer").Inc()
 			} else {
 				b.Logger.Debug(regErrF, "metric", metricName, "error", err)
-				b.ConflictingEventStats.WithLabelValues("observer").Inc()
+				b.ConflictingEventStats.WithLabelValues("observer", metricName).Inc()
 			}
 
 		default:

--- a/pkg/exporter/exporter_test.go
+++ b/pkg/exporter/exporter_test.go
@@ -117,7 +117,7 @@ var (
 			Name: "statsd_exporter_events_conflict_total",
 			Help: "The total number of StatsD events with conflicting names.",
 		},
-		[]string{"type"},
+		[]string{"type", "metric_name"},
 	)
 	errorEventStats = prometheus.NewCounterVec(
 		prometheus.CounterOpts{


### PR DESCRIPTION
## Summary

This is a modification we did to our internal version of the statsd-exporter and actually makes this metric actionable, so you can track down which metrics are problematic and fix them at the source (application code) or filter them out in the statsd exporter configuration.

If cardinality is a concern for other users, I can try enabling this behind a feature flag, and report a constant metric name if we dont want to track it.