### PR TITLE
pkg/line: support DogStatsD v1.3 metric timestamp field (|T<unix_ts>)

### DIFF
--- a/pkg/line/line.go
+++ b/pkg/line/line.go
@@ -269,7 +269,7 @@ samples:
 	for _, sample := range samples {
 		samplesReceived.Inc()
 		components := strings.Split(sample, "|")
-		if len(components) < 2 || len(components) > 5 {
+		if len(components) < 2 || len(components) > 8 {
 			sampleErrors.WithLabelValues("malformed_component").Inc()
 			logger.Debug("bad component", "line", line)
 			continue
@@ -327,6 +327,20 @@ samples:
 					} else {
 						logger.Debug("Malformed container ID section", "component", component, "line", line)
 						sampleErrors.WithLabelValues("malformed_container_id").Inc()
+						continue samples
+					}
+				case 'T':
+					// Handle DogStatsD v1.3 metric timestamp (e.g., |T1656581400).
+					// The timestamp is a Unix UTC epoch; statsd_exporter does not forward
+					// source timestamps to Prometheus, so we validate the field and ignore it.
+					if len(component) < 2 {
+						logger.Debug("Malformed timestamp section", "component", component, "line", line)
+						sampleErrors.WithLabelValues("malformed_timestamp").Inc()
+						continue samples
+					}
+					if _, err := strconv.ParseInt(component[1:], 10, 64); err != nil {
+						logger.Debug("Invalid timestamp value", "component", component[1:], "line", line)
+						sampleErrors.WithLabelValues("malformed_timestamp").Inc()
 						continue samples
 					}
 				default:

--- a/pkg/line/line_test.go
+++ b/pkg/line/line_test.go
@@ -926,6 +926,46 @@ func TestLineToEvents(t *testing.T) {
 			in:  "foo:100|c|@0.1|#tag1:value|c:container|extra:component",
 			out: event.Events{},
 		},
+		// DogStatsD v1.3 timestamp field (|T<unix_timestamp>)
+		"dogstatsd v1.3 timestamp counter": {
+			in: "page.views:15|c|#env:dev|T1656581400",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "page.views",
+					CValue:      15,
+					CLabels:     map[string]string{"env": "dev"},
+				},
+			},
+		},
+		"dogstatsd v1.3 timestamp gauge": {
+			in: "temperature:98.6|g|#location:kitchen|T1656581400",
+			out: event.Events{
+				&event.GaugeEvent{
+					GMetricName: "temperature",
+					GValue:      98.6,
+					GRelative:   false,
+					GLabels:     map[string]string{"location": "kitchen"},
+				},
+			},
+		},
+		"dogstatsd v1.3 timestamp with sampling and container": {
+			in: "requests:100|c|@0.1|#service:web|c:abc123|T1656581400",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "requests",
+					CValue:      1000,
+					CLabels:     map[string]string{"service": "web", "container_id": "abc123"},
+				},
+			},
+		},
+		"dogstatsd v1.3 timestamp malformed - no value": {
+			in:  "foo:100|c|#tag:val|T",
+			out: event.Events{},
+		},
+		"dogstatsd v1.3 timestamp malformed - non-numeric": {
+			in:  "foo:100|c|#tag:val|Tnot-a-ts",
+			out: event.Events{},
+		},
 	}
 
 	parser := NewParser()


### PR DESCRIPTION
## Summary

DogStatsD protocol v1.3 adds an optional timestamp suffix to the metric datagram:

```
<name>:<value>|<type>|#<tags>|T<unix_timestamp>
```

Previously any datagram containing this field was silently dropped because `T` was not a recognised component prefix (hit the `default` branch → `continue samples`) and the 5-component guard rejected fully-formed v1.3 datagrams.

## Changes

- **`pkg/line/line.go`**: add a `'T'` case in the component switch that validates the Unix timestamp integer and ignores it (statsd_exporter does not propagate source timestamps to Prometheus — same approach as the v1.2 `|c:<container_id>` field)
- Raise the max-components guard from `5` → `8` to accommodate all six possible v1.3 fields (`value`, `type`, `@sample`, `#tags`, `|c:`, `|T:`) without hitting a false `malformed_component` error
- **`pkg/line/line_test.go`**: five new test cases — counter, gauge, combined sampling+container+timestamp, and two malformed-timestamp cases

## Tests

```
go test ./pkg/line/...   # all pass
```

Fixes #680