### PR TITLE
feat(mapper): reject configs with unknown fields

### DIFF
--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -83,7 +83,10 @@ var defaultQuantiles = []MetricObjective{
 func (m *MetricMapper) InitFromYAMLString(fileContents string) error {
 	var n MetricMapper
 
-	if err := yaml.Unmarshal([]byte(fileContents), &n); err != nil {
+	// Use strict decoding so unknown or misspelled keys in a mapping
+	// config surface as an error instead of being silently dropped
+	// (see https://github.com/prometheus/statsd_exporter/issues/546).
+	if err := yaml.UnmarshalStrict([]byte(fileContents), &n); err != nil {
 		return err
 	}
 

--- a/pkg/mapper/mapper_test.go
+++ b/pkg/mapper/mapper_test.go
@@ -14,6 +14,7 @@
 package mapper
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -1758,5 +1759,30 @@ mappings:
 				}
 			}
 		}
+	}
+}
+
+// TestStrictConfigUnknownField covers the fix for
+// https://github.com/prometheus/statsd_exporter/issues/546: mapping
+// configs with keys the struct tags don't know about must fail to load
+// rather than silently drop the value.
+func TestStrictConfigUnknownField(t *testing.T) {
+	// `nmae` (misspelled `name`) is a field that MetricMapping doesn't
+	// expose; with permissive YAML it would be dropped, leaving the
+	// mapping without a metric name and producing a confusing runtime
+	// error much later (or none at all).
+	const badConfig = `---
+mappings:
+- match: aa.bb.*.*
+  nmae: "aa_bb_${1}_total"
+`
+
+	mapper := MetricMapper{}
+	err := mapper.InitFromYAMLString(badConfig)
+	if err == nil {
+		t.Fatal("expected InitFromYAMLString to reject unknown field `nmae`, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") && !strings.Contains(err.Error(), "field nmae") {
+		t.Fatalf("expected error to mention the unknown field, got: %v", err)
 	}
 }


### PR DESCRIPTION
Closes #546.

## Change

\`MetricMapper.InitFromYAMLString\` now parses the mapping config with \`yaml.UnmarshalStrict\` (already provided by \`go.yaml.in/yaml/v2\`). Any key that the target struct tags don't expose, a misspelled \`nmae:\` in place of \`name:\`, a stale field from an older version, etc., now fails to load with an error that names the unknown field, rather than being silently dropped.

This is exactly the failure mode the issue calls out (and the one that produced the confusion in #544 before it): the old permissive behavior made misconfigurations impossible to notice until the downstream mapping just didn't fire.

## Breaking change disclaimer

As the issue notes, this is \"potentially-breaking in the sense that your configuration no longer silently does something you didn't expect\". Any config file that was relying on unknown keys being ignored will start returning an error on reload. That's intentional, the whole point is to surface those. Release notes should highlight it, and my PR description here is the natural anchor for that note.

## Tests

Added \`TestStrictConfigUnknownField\` in \`pkg/mapper/mapper_test.go\` that feeds a mapping entry with a misspelled \`nmae:\` key and asserts that \`InitFromYAMLString\` returns an error mentioning the unknown field:

\`\`\`
$ go test -count=1 -run TestStrictConfigUnknownField -v ./pkg/mapper/...
=== RUN   TestStrictConfigUnknownField
--- PASS: TestStrictConfigUnknownField (0.00s)
PASS
\`\`\`

Full suite (\`go test -count=1 ./...\`) passes.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>