### PR TITLE
ci: pin contents: read on the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches: [main, master, 'release-*']
     tags: ['v*']
 
+permissions:
+  contents: read
+
 jobs:
   test_go:
     name: Go tests


### PR DESCRIPTION
Adds an explicit top-level `permissions: contents: read` block to `ci.yml` — matches the pattern in sibling prometheus repos. Image pushes use Docker Hub + Quay creds, so the default `GITHUB_TOKEN` doesn't need write scopes.