### PR TITLE
Reject unknown fields in mapping configuration

### DIFF
--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -83,7 +83,7 @@ var defaultQuantiles = []MetricObjective{
 func (m *MetricMapper) InitFromYAMLString(fileContents string) error {
 	var n MetricMapper
 
-	if err := yaml.Unmarshal([]byte(fileContents), &n); err != nil {
+	if err := yaml.UnmarshalStrict([]byte(fileContents), &n); err != nil {
 		return err
 	}
 

--- a/pkg/mapper/mapper_test.go
+++ b/pkg/mapper/mapper_test.go
@@ -503,6 +503,40 @@ mappings:
 			configBad: true,
 		},
 		{
+			testName: "Config with unknown top-level field",
+			config: `---
+notafield: true
+mappings:
+- match: test.*.*
+  name: "foo"
+  labels: {}
+  `,
+			configBad: true,
+		},
+		{
+			testName: "Config with unknown defaults field",
+			config: `---
+defaults:
+  notafield: true
+mappings:
+- match: test.*.*
+  name: "foo"
+  labels: {}
+  `,
+			configBad: true,
+		},
+		{
+			testName: "Config with unknown mapping field",
+			config: `---
+mappings:
+- match: test.*.*
+  name: "foo"
+  labels: {}
+  notafield: true
+  `,
+			configBad: true,
+		},
+		{
 			testName: "Config with no mappings",
 			config:   ``,
 			mappings: mappings{},


### PR DESCRIPTION
`InitFromYAMLString` used `yaml.Unmarshal`, which silently drops keys that don't match a struct field. A typo in a mapping or `defaults` key would be ignored, so the config quietly behaved differently than intended (see #544).

This switches to `yaml.UnmarshalStrict` so unknown keys are reported as an error. The deprecated `timer_type`, `buckets` and `quantiles` keys still work, since the alias structs the custom unmarshalers use already declare them. Added tests for an unknown key at the top level, in `defaults`, and in a mapping.

As noted in the issue this is technically a breaking change, in the sense that a config which silently did the wrong thing now fails loudly, so it probably wants a `[CHANGE]` changelog line at release.

Closes #546