### PR TITLE
Fix the list of maintainers to have appropriate format

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,2 +1,2 @@
-* Matthias Rampke <matthias@prometheus.io>
-* Pedro Tanaka [@pedro-stanaka](https://github.com/pedro-stanaka)
+* Matthias Rampke <matthias@prometheus.io> @matthiasr
+* Pedro Tanaka <me@pedrotanaka.com.br> @pedro-stanaka


### PR DESCRIPTION
Updates the list of the maintainers to have the proper format.

Closes https://github.com/prometheus/statsd_exporter/issues/696.
