### PR TITLE
fix: avoid nil logger panic in mapper init

### DIFF
--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -83,6 +83,10 @@ var defaultQuantiles = []MetricObjective{
 func (m *MetricMapper) InitFromYAMLString(fileContents string) error {
 	var n MetricMapper
 
+	if m.Logger == nil {
+		m.Logger = promslog.NewNopLogger()
+	}
+
 	if err := yaml.Unmarshal([]byte(fileContents), &n); err != nil {
 		return err
 	}
@@ -240,10 +244,6 @@ func (m *MetricMapper) InitFromYAMLString(fileContents string) error {
 
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-
-	if m.Logger == nil {
-		m.Logger = promslog.NewNopLogger()
-	}
 
 	m.Defaults = n.Defaults
 	m.Mappings = n.Mappings

--- a/pkg/mapper/mapper_test.go
+++ b/pkg/mapper/mapper_test.go
@@ -1719,6 +1719,31 @@ mappings:
 	}
 }
 
+func TestInitFromYAMLStringDeprecatedBucketsWithoutLogger(t *testing.T) {
+	config := `---
+defaults:
+  observer_type: histogram
+mappings:
+- match: test.*
+  observer_type: histogram
+  buckets: [1, 2, 3]
+  name: foo
+  labels: {}
+`
+
+	mapper := &MetricMapper{}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("InitFromYAMLString panicked with deprecated buckets and nil logger: %v", r)
+		}
+	}()
+
+	if err := mapper.InitFromYAMLString(config); err != nil {
+		t.Fatalf("InitFromYAMLString returned error: %v", err)
+	}
+}
+
 // Test for https://github.com/prometheus/statsd_exporter/issues/273
 // Corrupt cache for multiple names matching in fsm
 func TestMultipleMatches(t *testing.T) {


### PR DESCRIPTION
@matthiasr @pedro-stanaka

small panic fix.

If `pkg/mapper` is used with `&mapper.MetricMapper{}` and the config still uses deprecated `buckets`, `InitFromYAMLString` hits `m.Logger.Warn(...)` before the nil logger gets initialized, so it blows up.

This just initializes the nop logger first and adds a regression test.

How to repro:
1. make `m := &mapper.MetricMapper{}`
2. call `m.InitFromYAMLString(cfg)` with:

```yaml
defaults:
  observer_type: histogram
mappings:
- match: foo
  name: foo
  observer_type: histogram
  buckets: [1, 2, 3]
```

Before: panic
After: returns cleanly

This is reachable in real code too, not a made up edge case. `prometheus/graphite_exporter` has `metricMapper := &mapper.MetricMapper{}` in `cmd/getool/backfill.go`, so this path is live.
