### PR TITLE
Reject configuration with unknown fields

### DIFF
--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -87,7 +87,7 @@ func (m *MetricMapper) InitFromYAMLString(fileContents string) error {
 		m.Logger = promslog.NewNopLogger()
 	}
 
-	if err := yaml.Unmarshal([]byte(fileContents), &n); err != nil {
+	if err := yaml.UnmarshalStrict([]byte(fileContents), &n); err != nil {
 		return err
 	}
 

--- a/pkg/mapper/mapper_test.go
+++ b/pkg/mapper/mapper_test.go
@@ -493,6 +493,25 @@ mappings:
 			configBad: true,
 		},
 		{
+			testName: "Config with unknown top-level field",
+			config: `---
+mappingz:
+- match: test.*.*
+  name: "foo"
+  `,
+			configBad: true,
+		},
+		{
+			testName: "Config with unknown mapping field",
+			config: `---
+mappings:
+- match: test.*.*
+  name: "foo"
+  labelz: {}
+  `,
+			configBad: true,
+		},
+		{
 			testName: "Config with no metric name",
 			config: `---
 mappings:


### PR DESCRIPTION
Fixes #546.

This switches `MetricMapper.InitFromYAMLString` from `yaml.Unmarshal` to `yaml.UnmarshalStrict`, so that mapping configs containing unknown or misspelled fields fail loudly instead of being silently ignored (the kind of problem seen in #544).

### Behavior change
This is potentially breaking: configurations that previously loaded while silently ignoring unrecognized fields will now return an error. Probably worth a `[CHANGE]` note in the changelog at release time.

### Tests
Added two cases to `TestMetricMapperYAML` covering an unknown top-level field and an unknown per-mapping field. Verified they fail without this change and pass with it; the full test suite passes.

cc @matthiasr @pedro-stanaka
