### PR TITLE
feat: add current metrics gauge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## unreleased
+* [ENHANCEMENT] Add `statsd_exporter_metrics_current` gauge for the current number of active metric vectors by type.
+
 ## 0.30.0 / 2026-05-28
 * [CHANGE] Remove the Dockerfile `HEALTHCHECK` from published container images ([#671](https://github.com/prometheus/statsd_exporter/pull/671))
 * [ENHANCEMENT] Add a distroless container image variant ([#703](https://github.com/prometheus/statsd_exporter/pull/703))

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -760,7 +760,7 @@ mappings:
 	events := make(chan event.Events)
 	defer close(events)
 	go func() {
-		ex := exporter.NewExporter(prometheus.DefaultRegisterer, testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount)
+		ex := exporter.NewExporter(prometheus.DefaultRegisterer, testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount, metricsCurrent)
 		ex.Listen(events)
 	}()
 

--- a/exporter_benchmark_test.go
+++ b/exporter_benchmark_test.go
@@ -176,7 +176,7 @@ mappings:
 		b.Fatalf("Config load error: %s %s", config, err)
 	}
 
-	ex := exporter.NewExporter(prometheus.DefaultRegisterer, testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount)
+	ex := exporter.NewExporter(prometheus.DefaultRegisterer, testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount, metricsCurrent)
 
 	// reset benchmark timer to not measure startup costs
 	b.ResetTimer()

--- a/main.go
+++ b/main.go
@@ -171,6 +171,13 @@ var (
 		},
 		[]string{"type"},
 	)
+	metricsCurrent = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "statsd_exporter_metrics_current",
+			Help: "The current number of metric vectors with active time series.",
+		},
+		[]string{"type"},
+	)
 )
 
 func serveHTTP(mux http.Handler, listenAddress string, logger *slog.Logger) {
@@ -326,7 +333,7 @@ func main() {
 		}
 	}
 
-	exporter := exporter.NewExporter(prometheus.DefaultRegisterer, thisMapper, logger, eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount)
+	exporter := exporter.NewExporter(prometheus.DefaultRegisterer, thisMapper, logger, eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount, metricsCurrent)
 
 	if *checkConfig {
 		logger.Info("Configuration check successful, exiting")

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -32,11 +32,11 @@ const (
 )
 
 type Registry interface {
-	GetCounter(metricName string, labels prometheus.Labels, help string, mapping *mapper.MetricMapping, metricsCount *prometheus.GaugeVec) (prometheus.Counter, error)
-	GetGauge(metricName string, labels prometheus.Labels, help string, mapping *mapper.MetricMapping, metricsCount *prometheus.GaugeVec) (prometheus.Gauge, error)
-	GetHistogram(metricName string, labels prometheus.Labels, help string, mapping *mapper.MetricMapping, metricsCount *prometheus.GaugeVec) (prometheus.Observer, error)
-	GetSummary(metricName string, labels prometheus.Labels, help string, mapping *mapper.MetricMapping, metricsCount *prometheus.GaugeVec) (prometheus.Observer, error)
-	RemoveStaleMetrics()
+	GetCounter(metricName string, labels prometheus.Labels, help string, mapping *mapper.MetricMapping, metricsCount, metricsCurrent *prometheus.GaugeVec) (prometheus.Counter, error)
+	GetGauge(metricName string, labels prometheus.Labels, help string, mapping *mapper.MetricMapping, metricsCount, metricsCurrent *prometheus.GaugeVec) (prometheus.Gauge, error)
+	GetHistogram(metricName string, labels prometheus.Labels, help string, mapping *mapper.MetricMapping, metricsCount, metricsCurrent *prometheus.GaugeVec) (prometheus.Observer, error)
+	GetSummary(metricName string, labels prometheus.Labels, help string, mapping *mapper.MetricMapping, metricsCount, metricsCurrent *prometheus.GaugeVec) (prometheus.Observer, error)
+	RemoveStaleMetrics(metricsCurrent *prometheus.GaugeVec)
 }
 
 type Exporter struct {
@@ -49,6 +49,7 @@ type Exporter struct {
 	EventStats            *prometheus.CounterVec
 	ConflictingEventStats *prometheus.CounterVec
 	MetricsCount          *prometheus.GaugeVec
+	MetricsCurrent        *prometheus.GaugeVec
 }
 
 // Listen handles all events sent to the given channel sequentially. It
@@ -59,7 +60,7 @@ func (b *Exporter) Listen(e <-chan event.Events) {
 	for {
 		select {
 		case <-removeStaleMetricsTicker.C:
-			b.Registry.RemoveStaleMetrics()
+			b.Registry.RemoveStaleMetrics(b.MetricsCurrent)
 		case events, ok := <-e:
 			if !ok {
 				b.Logger.Debug("Channel is closed. Break out of Exporter.Listener.")
@@ -131,7 +132,7 @@ func (b *Exporter) handleEvent(thisEvent event.Event) {
 			return
 		}
 
-		counter, err := b.Registry.GetCounter(metricName, prometheusLabels, help, mapping, b.MetricsCount)
+		counter, err := b.Registry.GetCounter(metricName, prometheusLabels, help, mapping, b.MetricsCount, b.MetricsCurrent)
 		if err == nil {
 			counter.Add(eventValue)
 			b.EventStats.WithLabelValues("counter").Inc()
@@ -141,7 +142,7 @@ func (b *Exporter) handleEvent(thisEvent event.Event) {
 		}
 
 	case *event.GaugeEvent:
-		gauge, err := b.Registry.GetGauge(metricName, prometheusLabels, help, mapping, b.MetricsCount)
+		gauge, err := b.Registry.GetGauge(metricName, prometheusLabels, help, mapping, b.MetricsCount, b.MetricsCurrent)
 
 		if err == nil {
 			if ev.GRelative {
@@ -166,7 +167,7 @@ func (b *Exporter) handleEvent(thisEvent event.Event) {
 
 		switch t {
 		case mapper.ObserverTypeHistogram:
-			histogram, err := b.Registry.GetHistogram(metricName, prometheusLabels, help, mapping, b.MetricsCount)
+			histogram, err := b.Registry.GetHistogram(metricName, prometheusLabels, help, mapping, b.MetricsCount, b.MetricsCurrent)
 			if err == nil {
 				histogram.Observe(eventValue)
 				b.EventStats.WithLabelValues("observer").Inc()
@@ -176,7 +177,7 @@ func (b *Exporter) handleEvent(thisEvent event.Event) {
 			}
 
 		case mapper.ObserverTypeDefault, mapper.ObserverTypeSummary:
-			summary, err := b.Registry.GetSummary(metricName, prometheusLabels, help, mapping, b.MetricsCount)
+			summary, err := b.Registry.GetSummary(metricName, prometheusLabels, help, mapping, b.MetricsCount, b.MetricsCurrent)
 			if err == nil {
 				summary.Observe(eventValue)
 				b.EventStats.WithLabelValues("observer").Inc()
@@ -196,7 +197,7 @@ func (b *Exporter) handleEvent(thisEvent event.Event) {
 	}
 }
 
-func NewExporter(reg prometheus.Registerer, mapper *mapper.MetricMapper, logger *slog.Logger, eventsActions *prometheus.CounterVec, eventsUnmapped prometheus.Counter, errorEventStats, eventStats, conflictingEventStats *prometheus.CounterVec, metricsCount *prometheus.GaugeVec) *Exporter {
+func NewExporter(reg prometheus.Registerer, mapper *mapper.MetricMapper, logger *slog.Logger, eventsActions *prometheus.CounterVec, eventsUnmapped prometheus.Counter, errorEventStats, eventStats, conflictingEventStats *prometheus.CounterVec, metricsCount, metricsCurrent *prometheus.GaugeVec) *Exporter {
 	return &Exporter{
 		Mapper:                mapper,
 		Registry:              registry.NewRegistry(reg, mapper),
@@ -207,5 +208,6 @@ func NewExporter(reg prometheus.Registerer, mapper *mapper.MetricMapper, logger 
 		EventStats:            eventStats,
 		ConflictingEventStats: conflictingEventStats,
 		MetricsCount:          metricsCount,
+		MetricsCurrent:        metricsCurrent,
 	}
 }

--- a/pkg/exporter/exporter_test.go
+++ b/pkg/exporter/exporter_test.go
@@ -140,6 +140,13 @@ var (
 		},
 		[]string{"type"},
 	)
+	metricsCurrent = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "statsd_exporter_metrics_current",
+			Help: "The current number of metric vectors with active time series.",
+		},
+		[]string{"type"},
+	)
 )
 
 // TestNegativeCounter validates when we send a negative
@@ -173,7 +180,7 @@ func TestNegativeCounter(t *testing.T) {
 
 	testMapper := mapper.MetricMapper{}
 
-	ex := NewExporter(prometheus.DefaultRegisterer, &testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount)
+	ex := NewExporter(prometheus.DefaultRegisterer, &testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount, metricsCurrent)
 	ex.Listen(events)
 
 	updated := getTelemetryCounterValue(errorCounter)
@@ -254,7 +261,7 @@ mappings:
 		t.Fatalf("Config load error: %s %s", config, err)
 	}
 
-	ex := NewExporter(prometheus.DefaultRegisterer, testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount)
+	ex := NewExporter(prometheus.DefaultRegisterer, testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount, metricsCurrent)
 	ex.Listen(events)
 
 	metrics, err := prometheus.DefaultGatherer.Gather()
@@ -317,7 +324,7 @@ mappings:
 		t.Fatalf("Config load error: %s %s", config, err)
 	}
 
-	ex := NewExporter(prometheus.DefaultRegisterer, testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount)
+	ex := NewExporter(prometheus.DefaultRegisterer, testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount, metricsCurrent)
 	ex.Listen(events)
 
 	metrics, err := prometheus.DefaultGatherer.Gather()
@@ -367,7 +374,7 @@ mappings:
 		t.Fatalf("Config load error: %s %s", config, err)
 	}
 
-	ex := NewExporter(prometheus.DefaultRegisterer, testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount)
+	ex := NewExporter(prometheus.DefaultRegisterer, testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount, metricsCurrent)
 	ex.Listen(events)
 
 	metrics, err := prometheus.DefaultGatherer.Gather()
@@ -648,7 +655,7 @@ mappings:
 				close(events)
 			}()
 			reg := prometheus.NewRegistry()
-			ex := NewExporter(reg, testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount)
+			ex := NewExporter(reg, testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount, metricsCurrent)
 			ex.Listen(events)
 
 			metrics, err := reg.Gather()
@@ -703,7 +710,7 @@ mappings:
 	errorCounter := errorEventStats.WithLabelValues("empty_metric_name")
 	prev := getTelemetryCounterValue(errorCounter)
 
-	ex := NewExporter(prometheus.DefaultRegisterer, testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount)
+	ex := NewExporter(prometheus.DefaultRegisterer, testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount, metricsCurrent)
 	ex.Listen(events)
 
 	updated := getTelemetryCounterValue(errorCounter)
@@ -770,7 +777,7 @@ func TestInvalidUtf8InDatadogTagValue(t *testing.T) {
 
 	testMapper := mapper.MetricMapper{}
 
-	ex := NewExporter(prometheus.DefaultRegisterer, &testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount)
+	ex := NewExporter(prometheus.DefaultRegisterer, &testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount, metricsCurrent)
 	ex.Listen(events)
 }
 
@@ -783,7 +790,7 @@ func TestSummaryWithQuantilesEmptyMapping(t *testing.T) {
 	go func() {
 		testMapper := mapper.MetricMapper{}
 
-		ex := NewExporter(prometheus.DefaultRegisterer, &testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount)
+		ex := NewExporter(prometheus.DefaultRegisterer, &testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount, metricsCurrent)
 		ex.Listen(events)
 	}()
 
@@ -826,7 +833,7 @@ func TestHistogramUnits(t *testing.T) {
 	events := make(chan event.Events)
 	go func() {
 		testMapper := mapper.MetricMapper{}
-		ex := NewExporter(prometheus.DefaultRegisterer, &testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount)
+		ex := NewExporter(prometheus.DefaultRegisterer, &testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount, metricsCurrent)
 		ex.Mapper.Defaults.ObserverType = mapper.ObserverTypeHistogram
 		ex.Listen(events)
 	}()
@@ -863,7 +870,7 @@ func TestCounterIncrement(t *testing.T) {
 	events := make(chan event.Events)
 	go func() {
 		testMapper := mapper.MetricMapper{}
-		ex := NewExporter(prometheus.DefaultRegisterer, &testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount)
+		ex := NewExporter(prometheus.DefaultRegisterer, &testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount, metricsCurrent)
 		ex.Listen(events)
 	}()
 
@@ -910,7 +917,7 @@ func TestGaugeIncrementDecrement(t *testing.T) {
 	events := make(chan event.Events)
 	go func() {
 		testMapper := mapper.MetricMapper{}
-		ex := NewExporter(prometheus.DefaultRegisterer, &testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount)
+		ex := NewExporter(prometheus.DefaultRegisterer, &testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount, metricsCurrent)
 		ex.Listen(events)
 	}()
 
@@ -972,7 +979,7 @@ func TestScaledMapping(t *testing.T) {
 
 	// Start exporter with a synchronous channel
 	go func() {
-		ex := NewExporter(prometheus.DefaultRegisterer, &testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount)
+		ex := NewExporter(prometheus.DefaultRegisterer, &testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount, metricsCurrent)
 		ex.Listen(events)
 	}()
 
@@ -1081,7 +1088,7 @@ mappings:
 	events := make(chan event.Events)
 	defer close(events)
 	go func() {
-		ex := NewExporter(prometheus.DefaultRegisterer, testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount)
+		ex := NewExporter(prometheus.DefaultRegisterer, testMapper, promslog.NewNopLogger(), eventsActions, eventsUnmapped, errorEventStats, eventStats, conflictingEventStats, metricsCount, metricsCurrent)
 		ex.Listen(events)
 	}()
 
@@ -1165,6 +1172,62 @@ mappings:
 	}
 	if foobarValue != nil {
 		t.Fatalf("Gauge `foobar` should not be gathered after expiration")
+	}
+}
+
+func TestMetricsCurrentTracksActiveMetricVectors(t *testing.T) {
+	clock.ClockInstance = &clock.Clock{}
+	defer func() {
+		clock.ClockInstance = nil
+	}()
+
+	reg := prometheus.NewRegistry()
+	testMapper := &mapper.MetricMapper{}
+	r := registry.NewRegistry(reg, testMapper)
+	metricsCount := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "statsd_exporter_metrics_total",
+			Help: "The total number of metrics.",
+		},
+		[]string{"type"},
+	)
+	metricsCurrent := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "statsd_exporter_metrics_current",
+			Help: "The current number of metric vectors with active time series.",
+		},
+		[]string{"type"},
+	)
+	mapping := &mapper.MetricMapping{Ttl: time.Second}
+
+	clock.ClockInstance.Instant = time.Unix(0, 0)
+	_, err := r.GetGauge("current_gauge", prometheus.Labels{"label": "first"}, defaultHelp, mapping, metricsCount, metricsCurrent)
+	if err != nil {
+		t.Fatalf("GetGauge failed: %v", err)
+	}
+
+	clock.ClockInstance.Instant = time.Unix(0, int64(500*time.Millisecond))
+	_, err = r.GetGauge("current_gauge", prometheus.Labels{"label": "second"}, defaultHelp, mapping, metricsCount, metricsCurrent)
+	if err != nil {
+		t.Fatalf("GetGauge failed: %v", err)
+	}
+
+	if current := getTelemetryGaugeValue(metricsCurrent.WithLabelValues("gauge")); current != 1 {
+		t.Fatalf("expected one active gauge vector, got %v", current)
+	}
+
+	clock.ClockInstance.Instant = time.Unix(1, int64(100*time.Millisecond))
+	r.RemoveStaleMetrics(metricsCurrent)
+
+	if current := getTelemetryGaugeValue(metricsCurrent.WithLabelValues("gauge")); current != 1 {
+		t.Fatalf("expected gauge vector to remain active while one series is still present, got %v", current)
+	}
+
+	clock.ClockInstance.Instant = time.Unix(1, int64(600*time.Millisecond))
+	r.RemoveStaleMetrics(metricsCurrent)
+
+	if current := getTelemetryGaugeValue(metricsCurrent.WithLabelValues("gauge")); current != 0 {
+		t.Fatalf("expected gauge vector to be inactive after all series expire, got %v", current)
 	}
 }
 
@@ -1273,6 +1336,15 @@ func getTelemetryCounterValue(counter prometheus.Counter) float64 {
 		return 0.0
 	}
 	return metric.Counter.GetValue()
+}
+
+func getTelemetryGaugeValue(gauge prometheus.Gauge) float64 {
+	var metric dto.Metric
+	err := gauge.Write(&metric)
+	if err != nil {
+		return 0.0
+	}
+	return metric.Gauge.GetValue()
 }
 
 func BenchmarkParseDogStatsDTags(b *testing.B) {

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -79,23 +79,23 @@ func (r *Registry) MetricConflicts(metricName string, metricType metrics.MetricT
 	return true
 }
 
-func (r *Registry) StoreCounter(metricName string, hash metrics.LabelHash, labels prometheus.Labels, vec *prometheus.CounterVec, c prometheus.Counter, ttl time.Duration) {
-	r.Store(metricName, hash, labels, vec, c, metrics.CounterMetricType, ttl)
+func (r *Registry) StoreCounter(metricName string, hash metrics.LabelHash, labels prometheus.Labels, vec *prometheus.CounterVec, c prometheus.Counter, ttl time.Duration) bool {
+	return r.Store(metricName, hash, labels, vec, c, metrics.CounterMetricType, ttl)
 }
 
-func (r *Registry) StoreGauge(metricName string, hash metrics.LabelHash, labels prometheus.Labels, vec *prometheus.GaugeVec, g prometheus.Gauge, ttl time.Duration) {
-	r.Store(metricName, hash, labels, vec, g, metrics.GaugeMetricType, ttl)
+func (r *Registry) StoreGauge(metricName string, hash metrics.LabelHash, labels prometheus.Labels, vec *prometheus.GaugeVec, g prometheus.Gauge, ttl time.Duration) bool {
+	return r.Store(metricName, hash, labels, vec, g, metrics.GaugeMetricType, ttl)
 }
 
-func (r *Registry) StoreHistogram(metricName string, hash metrics.LabelHash, labels prometheus.Labels, vec *prometheus.HistogramVec, o prometheus.Observer, ttl time.Duration) {
-	r.Store(metricName, hash, labels, vec, o, metrics.HistogramMetricType, ttl)
+func (r *Registry) StoreHistogram(metricName string, hash metrics.LabelHash, labels prometheus.Labels, vec *prometheus.HistogramVec, o prometheus.Observer, ttl time.Duration) bool {
+	return r.Store(metricName, hash, labels, vec, o, metrics.HistogramMetricType, ttl)
 }
 
-func (r *Registry) StoreSummary(metricName string, hash metrics.LabelHash, labels prometheus.Labels, vec *prometheus.SummaryVec, o prometheus.Observer, ttl time.Duration) {
-	r.Store(metricName, hash, labels, vec, o, metrics.SummaryMetricType, ttl)
+func (r *Registry) StoreSummary(metricName string, hash metrics.LabelHash, labels prometheus.Labels, vec *prometheus.SummaryVec, o prometheus.Observer, ttl time.Duration) bool {
+	return r.Store(metricName, hash, labels, vec, o, metrics.SummaryMetricType, ttl)
 }
 
-func (r *Registry) Store(metricName string, hash metrics.LabelHash, labels prometheus.Labels, vh metrics.VectorHolder, mh metrics.MetricHolder, metricType metrics.MetricType, ttl time.Duration) {
+func (r *Registry) Store(metricName string, hash metrics.LabelHash, labels prometheus.Labels, vh metrics.VectorHolder, mh metrics.MetricHolder, metricType metrics.MetricType, ttl time.Duration) bool {
 	metric, hasMetrics := r.Metrics[metricName]
 	if !hasMetrics {
 		metric.MetricType = metricType
@@ -122,12 +122,14 @@ func (r *Registry) Store(metricName string, hash metrics.LabelHash, labels prome
 			VecKey:           hash.Names,
 		}
 		metric.Metrics[hash.Values] = rm
+		activatedVector := v.RefCount == 0
 		v.RefCount++
-		return
+		return activatedVector
 	}
 	rm.LastRegisteredAt = now
 	// Update ttl from mapping
 	rm.TTL = ttl
+	return false
 }
 
 func (r *Registry) Get(metricName string, hash metrics.LabelHash, metricType metrics.MetricType) (metrics.VectorHolder, metrics.MetricHolder) {
@@ -155,7 +157,7 @@ func (r *Registry) Get(metricName string, hash metrics.LabelHash, metricType met
 	return nil, nil
 }
 
-func (r *Registry) GetCounter(metricName string, labels prometheus.Labels, help string, mapping *mapper.MetricMapping, metricsCount *prometheus.GaugeVec) (prometheus.Counter, error) {
+func (r *Registry) GetCounter(metricName string, labels prometheus.Labels, help string, mapping *mapper.MetricMapping, metricsCount, metricsCurrent *prometheus.GaugeVec) (prometheus.Counter, error) {
 	hash, labelNames := r.HashLabels(labels)
 	vh, mh := r.Get(metricName, hash, metrics.CounterMetricType)
 	if mh != nil {
@@ -190,7 +192,9 @@ func (r *Registry) GetCounter(metricName string, labels prometheus.Labels, help 
 	if counter, err = counterVec.GetMetricWith(labels); err != nil {
 		return nil, err
 	}
-	r.StoreCounter(metricName, hash, labels, counterVec, counter, mapping.Ttl)
+	if r.StoreCounter(metricName, hash, labels, counterVec, counter, mapping.Ttl) {
+		recordMetricActivated(metricsCurrent, metrics.CounterMetricType)
+	}
 
 	return counter, nil
 }
@@ -207,7 +211,7 @@ func (r *Registry) checkHistogramNameCollision(metricName string) error {
 	return nil
 }
 
-func (r *Registry) GetGauge(metricName string, labels prometheus.Labels, help string, mapping *mapper.MetricMapping, metricsCount *prometheus.GaugeVec) (prometheus.Gauge, error) {
+func (r *Registry) GetGauge(metricName string, labels prometheus.Labels, help string, mapping *mapper.MetricMapping, metricsCount, metricsCurrent *prometheus.GaugeVec) (prometheus.Gauge, error) {
 	hash, labelNames := r.HashLabels(labels)
 	vh, mh := r.Get(metricName, hash, metrics.GaugeMetricType)
 	if mh != nil {
@@ -242,12 +246,14 @@ func (r *Registry) GetGauge(metricName string, labels prometheus.Labels, help st
 	if gauge, err = gaugeVec.GetMetricWith(labels); err != nil {
 		return nil, err
 	}
-	r.StoreGauge(metricName, hash, labels, gaugeVec, gauge, mapping.Ttl)
+	if r.StoreGauge(metricName, hash, labels, gaugeVec, gauge, mapping.Ttl) {
+		recordMetricActivated(metricsCurrent, metrics.GaugeMetricType)
+	}
 
 	return gauge, nil
 }
 
-func (r *Registry) GetHistogram(metricName string, labels prometheus.Labels, help string, mapping *mapper.MetricMapping, metricsCount *prometheus.GaugeVec) (prometheus.Observer, error) {
+func (r *Registry) GetHistogram(metricName string, labels prometheus.Labels, help string, mapping *mapper.MetricMapping, metricsCount, metricsCurrent *prometheus.GaugeVec) (prometheus.Observer, error) {
 	hash, labelNames := r.HashLabels(labels)
 	vh, mh := r.Get(metricName, hash, metrics.HistogramMetricType)
 	if mh != nil {
@@ -304,12 +310,14 @@ func (r *Registry) GetHistogram(metricName string, labels prometheus.Labels, hel
 	if observer, err = histogramVec.GetMetricWith(labels); err != nil {
 		return nil, err
 	}
-	r.StoreHistogram(metricName, hash, labels, histogramVec, observer, mapping.Ttl)
+	if r.StoreHistogram(metricName, hash, labels, histogramVec, observer, mapping.Ttl) {
+		recordMetricActivated(metricsCurrent, metrics.HistogramMetricType)
+	}
 
 	return observer, nil
 }
 
-func (r *Registry) GetSummary(metricName string, labels prometheus.Labels, help string, mapping *mapper.MetricMapping, metricsCount *prometheus.GaugeVec) (prometheus.Observer, error) {
+func (r *Registry) GetSummary(metricName string, labels prometheus.Labels, help string, mapping *mapper.MetricMapping, metricsCount, metricsCurrent *prometheus.GaugeVec) (prometheus.Observer, error) {
 	hash, labelNames := r.HashLabels(labels)
 	vh, mh := r.Get(metricName, hash, metrics.SummaryMetricType)
 	if mh != nil {
@@ -373,12 +381,14 @@ func (r *Registry) GetSummary(metricName string, labels prometheus.Labels, help 
 	if observer, err = summaryVec.GetMetricWith(labels); err != nil {
 		return nil, err
 	}
-	r.StoreSummary(metricName, hash, labels, summaryVec, observer, mapping.Ttl)
+	if r.StoreSummary(metricName, hash, labels, summaryVec, observer, mapping.Ttl) {
+		recordMetricActivated(metricsCurrent, metrics.SummaryMetricType)
+	}
 
 	return observer, nil
 }
 
-func (r *Registry) RemoveStaleMetrics() {
+func (r *Registry) RemoveStaleMetrics(metricsCurrent *prometheus.GaugeVec) {
 	now := clock.Now()
 	// delete timeseries with expired ttl
 	for _, metric := range r.Metrics {
@@ -387,11 +397,44 @@ func (r *Registry) RemoveStaleMetrics() {
 				continue
 			}
 			if rm.LastRegisteredAt.Add(rm.TTL).Before(now) {
-				metric.Vectors[rm.VecKey].Holder.Delete(rm.Labels)
-				metric.Vectors[rm.VecKey].RefCount--
+				vector := metric.Vectors[rm.VecKey]
+				vector.Holder.Delete(rm.Labels)
+				vector.RefCount--
+				if vector.RefCount == 0 {
+					recordMetricDeactivated(metricsCurrent, metric.MetricType)
+				}
 				delete(metric.Metrics, hash)
 			}
 		}
+	}
+}
+
+func recordMetricActivated(metricsCurrent *prometheus.GaugeVec, metricType metrics.MetricType) {
+	if metricsCurrent == nil {
+		return
+	}
+	metricsCurrent.WithLabelValues(metricTypeLabel(metricType)).Inc()
+}
+
+func recordMetricDeactivated(metricsCurrent *prometheus.GaugeVec, metricType metrics.MetricType) {
+	if metricsCurrent == nil {
+		return
+	}
+	metricsCurrent.WithLabelValues(metricTypeLabel(metricType)).Dec()
+}
+
+func metricTypeLabel(metricType metrics.MetricType) string {
+	switch metricType {
+	case metrics.CounterMetricType:
+		return "counter"
+	case metrics.GaugeMetricType:
+		return "gauge"
+	case metrics.HistogramMetricType:
+		return "histogram"
+	case metrics.SummaryMetricType:
+		return "summary"
+	default:
+		return "unknown"
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `statsd_exporter_metrics_current` to report the current number of active metric vectors by metric type
- keep `statsd_exporter_metrics_total` as the cumulative vector counter
- update the current gauge when metric vectors become active again or expire via TTL cleanup

Fixes #565

## Testing
- `go test ./pkg/registry ./pkg/exporter -run 'TestMetricsCurrentTracksActiveMetricVectors|TestTtlExpiration|TestHashLabelNames' -count=1`\n- `go test ./pkg/exporter -run TestMetricsCurrentTracksActiveMetricVectors -race -count=1`\n- `go test ./... -count=1`\n- `git diff --check`