### PR TITLE
Support $0 template reference in glob mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * [FEATURE] Support the optional DogStatsD v1.3 metric timestamp field (`|T<unix_timestamp>`) ([#716](https://github.com/prometheus/statsd_exporter/pull/716))
+* [FEATURE] Support `$0` template reference (the original, unmodified statsd metric name) in `glob` mappings, matching existing `regex` mapping behavior ([#735](https://github.com/prometheus/statsd_exporter/pull/735))
 
 ## 0.30.0 / 2026-05-28
 * [CHANGE] Remove the Dockerfile `HEALTHCHECK` from published container images ([#671](https://github.com/prometheus/statsd_exporter/pull/671))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Unreleased
 
 * [FEATURE] Support the optional DogStatsD v1.3 metric timestamp field (`|T<unix_timestamp>`) ([#716](https://github.com/prometheus/statsd_exporter/pull/716))
-* [FEATURE] Support `$0` template reference (the original, unmodified statsd metric name) in `glob` mappings, matching existing `regex` mapping behavior ([#735](https://github.com/prometheus/statsd_exporter/pull/735))
+* [FEATURE] Support `$0` template reference in `glob` mappings, expanding to the complete StatsD metric name (matching regex mappings, where `$0` expands to the complete regex match) ([#735](https://github.com/prometheus/statsd_exporter/pull/735))
+* [CHANGE][library] `fsm.TemplateFormatter.Format` now takes the original metric name as an additional first argument: `Format(metricName string, captures []string)` instead of `Format(captures []string)` ([#735](https://github.com/prometheus/statsd_exporter/pull/735))
 
 ## 0.30.0 / 2026-05-28
 * [CHANGE] Remove the Dockerfile `HEALTHCHECK` from published container images ([#671](https://github.com/prometheus/statsd_exporter/pull/671))

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ But the metric will also have the label `statsd_metric_name` with the value `my.
 
 Note: If you use the `match` like the example (i.e. `.+`), be aware that it will be a "catch-all" block. So it should come at the very end of the mapping list.
 
-Note: as with other `$n` references (for both `glob` and `regex` templates), use the `${0}` form (rather than `$0`) when it is immediately followed by other word characters or another `$`-reference, e.g. `${0}_total`, otherwise the reference will not be recognized and will resolve to an empty string.
+Note: as with other `$n` references (for both `glob` and `regex` templates), use the `${0}` form (rather than `$0`) when it is immediately followed by other word characters, e.g. `${0}_total`, otherwise the reference will not be recognized and will resolve to an empty string. For `glob` templates this also applies when `$0` is immediately followed by another `$`-reference, e.g. `${0}$1`; `regex` templates don't need bracing in that case, so `$0$1` works as-is.
 
 ### Naming, labels, and help
 

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ mappings:
 
 #### Special match groups
 
-The `$0` reference expands to the original, unmodified statsd metric name and can be used with both `glob` and `regex` matching to attach labels to the metric.
+With `glob`, `$0` expands to the complete StatsD metric name. With `regex`, `$0` expands to the complete regex match. Both can be used to attach labels to the metric.
 Example:
 
 ```yaml
@@ -277,7 +277,7 @@ But the metric will also have the label `statsd_metric_name` with the value `my.
 
 Note: If you use the `match` like the example (i.e. `.+`), be aware that it will be a "catch-all" block. So it should come at the very end of the mapping list.
 
-Note: as with other `$n` references, use the `${0}` form (rather than `$0`) when it is immediately followed by other word characters or another `$`-reference, e.g. `${0}_total`, otherwise the reference will not be recognized and will resolve to an empty string.
+Note: as with other `$n` references (for both `glob` and `regex` templates), use the `${0}` form (rather than `$0`) when it is immediately followed by other word characters or another `$`-reference, e.g. `${0}_total`, otherwise the reference will not be recognized and will resolve to an empty string.
 
 ### Naming, labels, and help
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,9 @@ follows:
 
 Each mapping in the configuration file must define a `name` for the metric. The
 metric's name can contain `$n`-style references to be replaced by the n-th
-wildcard match in the matching line. That allows for dynamic rewrites, such as:
+wildcard match in the matching line, as well as `$0` to reference the original,
+unmodified statsd metric name (see [Special match groups](#special-match-groups)).
+That allows for dynamic rewrites, such as:
 
 ```yaml
 mappings:
@@ -258,7 +260,7 @@ mappings:
 
 #### Special match groups
 
-When using regex, the match group `0` is the full match and can be used to attach labels to the metric.
+The `$0` reference expands to the original, unmodified statsd metric name and can be used with both `glob` and `regex` matching to attach labels to the metric.
 Example:
 
 ```yaml
@@ -275,7 +277,7 @@ But the metric will also have the label `statsd_metric_name` with the value `my.
 
 Note: If you use the `match` like the example (i.e. `.+`), be aware that it will be a "catch-all" block. So it should come at the very end of the mapping list.
 
-The same is not achievable with glob matching, for more details check [this issue](https://github.com/prometheus/statsd_exporter/issues/444).
+Note: as with other `$n` references, use the `${0}` form (rather than `$0`) when it is immediately followed by other word characters or another `$`-reference, e.g. `${0}_total`, otherwise the reference will not be recognized and will resolve to an empty string.
 
 ### Naming, labels, and help
 

--- a/pkg/mapper/fsm/formatter.go
+++ b/pkg/mapper/fsm/formatter.go
@@ -41,13 +41,14 @@ func NewTemplateFormatter(template string, captureCount int) *TemplateFormatter 
 	valueFormatter := template
 	for _, match := range matches {
 		idx, err := strconv.Atoi(match[len(match)-1])
-		if err != nil || idx > captureCount || idx < 1 {
+		if err != nil || idx > captureCount || idx < 0 {
 			// if index larger than captured count or using unsupported named capture group,
 			// replace with empty string
 			valueFormatter = strings.ReplaceAll(valueFormatter, match[0], "")
 		} else {
 			valueFormatter = strings.ReplaceAll(valueFormatter, match[0], "%s")
-			// note: the regex reference variable $? starts from 1
+			// note: the regex reference variable $? starts from 1, $0 refers to the
+			// original metric name and is represented here as index -1
 			indexes = append(indexes, idx-1)
 		}
 	}
@@ -58,9 +59,11 @@ func NewTemplateFormatter(template string, captureCount int) *TemplateFormatter 
 	}
 }
 
-// Format accepts a list containing captured strings and returns the formatted
-// string using the template stored in current TemplateFormatter.
-func (formatter *TemplateFormatter) Format(captures []string) string {
+// Format accepts the original metric name and a list containing captured
+// strings, and returns the formatted string using the template stored in
+// current TemplateFormatter. $0 refers to the original metric name, $1
+// onwards refer to the captured strings.
+func (formatter *TemplateFormatter) Format(metricName string, captures []string) string {
 	if formatter.captureCount == 0 {
 		// no label substitution, keep as it is
 		return formatter.fmtString
@@ -68,7 +71,11 @@ func (formatter *TemplateFormatter) Format(captures []string) string {
 	indexes := formatter.captureIndexes
 	vargs := make([]interface{}, formatter.captureCount)
 	for i, idx := range indexes {
-		vargs[i] = captures[idx]
+		if idx == -1 {
+			vargs[i] = metricName
+		} else {
+			vargs[i] = captures[idx]
+		}
 	}
 	return fmt.Sprintf(formatter.fmtString, vargs...)
 }

--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -282,11 +282,11 @@ func (m *MetricMapper) GetMapping(statsdMetric string, statsdMetricType MetricTy
 		if finalState != nil && finalState.Result != nil {
 			v := finalState.Result.(*MetricMapping)
 			result := copyMetricMapping(v)
-			result.Name = result.nameFormatter.Format(captures)
+			result.Name = result.nameFormatter.Format(statsdMetric, captures)
 
 			labels := prometheus.Labels{}
 			for index, formatter := range result.labelFormatters {
-				labels[result.labelKeys[index]] = formatter.Format(captures)
+				labels[result.labelKeys[index]] = formatter.Format(statsdMetric, captures)
 			}
 
 			r := MetricMapperCacheResult{

--- a/pkg/mapper/mapper_test.go
+++ b/pkg/mapper/mapper_test.go
@@ -483,6 +483,36 @@ mappings:
 			},
 		},
 		{
+			testName: "Config with $0 referencing the original metric name in glob mode",
+			config: `---
+mappings:
+- match: test1.*.*
+  name: "total_requests"
+  labels:
+    original: "$0"
+- match: test2.*.*
+  name: "${1}_$2"
+  labels:
+    original: "$0"
+  `,
+			mappings: mappings{
+				{
+					statsdMetric: "test1.total_requests.count",
+					name:         "total_requests",
+					labels: map[string]string{
+						"original": "test1.total_requests.count",
+					},
+				},
+				{
+					statsdMetric: "test2.total_requests.count",
+					name:         "total_requests_count",
+					labels: map[string]string{
+						"original": "test2.total_requests.count",
+					},
+				},
+			},
+		},
+		{
 			testName: "Config with bad metric name",
 			config: `---
 mappings:

--- a/pkg/mapper/mapper_test.go
+++ b/pkg/mapper/mapper_test.go
@@ -513,6 +513,104 @@ mappings:
 			},
 		},
 		{
+			testName: "Config with $0 in the metric name in glob mode",
+			config: `---
+mappings:
+- match: test1.*.*
+  name: "$0"
+  labels: {}
+  `,
+			mappings: mappings{
+				{
+					statsdMetric: "test1.total_requests.count",
+					name:         "test1.total_requests.count",
+				},
+			},
+		},
+		{
+			testName: "Config with $0 combined with $1 in glob mode",
+			config: `---
+mappings:
+- match: test1.*.*
+  name: "name"
+  labels:
+    combined: "${0}_$1"
+  `,
+			mappings: mappings{
+				{
+					statsdMetric: "test1.total_requests.count",
+					name:         "name",
+					labels: map[string]string{
+						"combined": "test1.total_requests.count_total_requests",
+					},
+				},
+			},
+		},
+		{
+			testName: "Config with $0 and an out-of-range $N reference in glob mode",
+			config: `---
+mappings:
+- match: test1.*.*
+  name: "name"
+  labels:
+    original: "$0"
+    outofrange: "$5"
+  `,
+			mappings: mappings{
+				{
+					statsdMetric: "test1.total_requests.count",
+					name:         "name",
+					labels: map[string]string{
+						"original":   "test1.total_requests.count",
+						"outofrange": "",
+					},
+				},
+			},
+		},
+		{
+			testName: "Config with $0 and a literal, no-wildcard glob",
+			config: `---
+mappings:
+- match: test1.total_requests.count
+  name: "name"
+  labels:
+    original: "$0"
+  `,
+			mappings: mappings{
+				{
+					statsdMetric: "test1.total_requests.count",
+					name:         "name",
+					labels: map[string]string{
+						"original": "test1.total_requests.count",
+					},
+				},
+			},
+		},
+		{
+			testName: "Config with $0 bracing behavior in glob mode",
+			config: `---
+mappings:
+- match: test1.*.*
+  name: "name"
+  labels:
+    unbraced: "$0_suffix"
+    braced: "${0}_suffix"
+  `,
+			mappings: mappings{
+				{
+					statsdMetric: "test1.total_requests.count",
+					name:         "name",
+					labels: map[string]string{
+						// $0_suffix is parsed as a single (unsupported) capture
+						// reference named "0_suffix" and resolves to empty, same
+						// as existing $N behavior without bracing.
+						"unbraced": "",
+						"braced":   "test1.total_requests.count_suffix",
+					},
+				},
+			},
+		},
+		{
 			testName: "Config with bad metric name",
 			config: `---
 mappings:


### PR DESCRIPTION
Motivation:
Split from #438, issue #444: with regex match_type, `$0` in a
mapping's `name` or a label value expands to the original,
unmodified statsd metric name via Go's regexp.Expand semantics.
Glob mappings used to be translated to regular expressions
internally, so `$0` also worked there, but that stopped working
when glob matching was rewritten to use a finite state machine
(FSM), since the FSM only tracks captured `*` segments, not the
full input metric name. Before this change, using `$0` with
`match_type: glob` silently expanded to an empty string (the
same fallback used for any out-of-range `$N` reference) rather
than erroring, so the loss was easy to miss.

Approach:
- pkg/mapper/fsm/formatter.go: TemplateFormatter.NewTemplateFormatter
  now accepts index 0 (previously rejected as `idx < 1`) and stores
  it as a sentinel (-1) alongside the existing capture indexes.
  TemplateFormatter.Format now takes the original metric name as an
  additional argument and substitutes it whenever the sentinel is
  seen, leaving existing $1..$N handling unchanged.
- pkg/mapper/mapper.go: pass the original statsdMetric string through
  to nameFormatter.Format and each label formatter's Format call.
- Updated README.md to document that `$0` now works for both `glob`
  and `regex` match types, and to note (matching existing $N
  behavior) that `${0}` bracing is required when immediately
  followed by other word characters or another `$`-reference.

Validation:
- go build ./... and go test ./... pass.
- Added a table-driven case to pkg/mapper/mapper_test.go
  (TestMetricMapperYAML) covering `$0` in both the metric `name`
  and a label value for glob mappings; verified this new case fails
  with the pre-fix code (empty label value) and passes with the fix.
- This is a feature restoration matching existing regex-mode `$0`
  behavior, not a crash/data-loss fix: before the fix, glob-mode
  `$0` silently resolved to an empty string, it did not error or
  panic.

Fixes #444

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>