### PR TITLE
feat: support $0 in glob mapping templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * [FEATURE] Support the optional DogStatsD v1.3 metric timestamp field (`|T<unix_timestamp>`) ([#716](https://github.com/prometheus/statsd_exporter/pull/716))
+* [FEATURE] Support `$0` to reference the whole metric name in glob mapping templates ([#736](https://github.com/prometheus/statsd_exporter/pull/736))
 
 ## 0.30.0 / 2026-05-28
 * [CHANGE] Remove the Dockerfile `HEALTHCHECK` from published container images ([#671](https://github.com/prometheus/statsd_exporter/pull/671))

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ mappings:
 
 #### Special match groups
 
-When using regex, the match group `0` is the full match and can be used to attach labels to the metric.
+The match group `0` is the full match and can be used to attach labels to the metric.
 Example:
 
 ```yaml
@@ -275,7 +275,17 @@ But the metric will also have the label `statsd_metric_name` with the value `my.
 
 Note: If you use the `match` like the example (i.e. `.+`), be aware that it will be a "catch-all" block. So it should come at the very end of the mapping list.
 
-The same is not achievable with glob matching, for more details check [this issue](https://github.com/prometheus/statsd_exporter/issues/444).
+`$0` works the same way in glob mappings, where it can be combined with the
+regular capture references:
+
+```yaml
+mappings:
+- match: "*.*"
+  name: "$0"
+  labels:
+    statsd_metric_name: "$0"
+    first: "$1"
+```
 
 ### Naming, labels, and help
 

--- a/pkg/mapper/fsm/formatter.go
+++ b/pkg/mapper/fsm/formatter.go
@@ -30,6 +30,7 @@ type TemplateFormatter struct {
 
 // NewTemplateFormatter instantiates a TemplateFormatter
 // from given template string and the maximum amount of captures.
+// captureCount is the number of captures in the match, not counting $0.
 func NewTemplateFormatter(template string, captureCount int) *TemplateFormatter {
 	matches := templateReplaceCaptureRE.FindAllStringSubmatch(template, -1)
 	if len(matches) == 0 {
@@ -41,14 +42,16 @@ func NewTemplateFormatter(template string, captureCount int) *TemplateFormatter 
 	valueFormatter := template
 	for _, match := range matches {
 		idx, err := strconv.Atoi(match[len(match)-1])
-		if err != nil || idx > captureCount || idx < 1 {
+		if err != nil || idx > captureCount || idx < 0 {
 			// if index larger than captured count or using unsupported named capture group,
 			// replace with empty string
 			valueFormatter = strings.ReplaceAll(valueFormatter, match[0], "")
 		} else {
 			valueFormatter = strings.ReplaceAll(valueFormatter, match[0], "%s")
-			// note: the regex reference variable $? starts from 1
-			indexes = append(indexes, idx-1)
+			// $0 is the whole metric name and the captures follow it, so the
+			// reference variable $? indexes directly into the captures passed
+			// to Format.
+			indexes = append(indexes, idx)
 		}
 	}
 	return &TemplateFormatter{
@@ -58,8 +61,10 @@ func NewTemplateFormatter(template string, captureCount int) *TemplateFormatter 
 	}
 }
 
-// Format accepts a list containing captured strings and returns the formatted
-// string using the template stored in current TemplateFormatter.
+// Format accepts a list containing the whole metric name followed by the
+// captured strings, and returns the formatted string using the template stored
+// in current TemplateFormatter. The metric name is at index 0, so it is
+// referenced as $0, matching the behaviour of the regex match type.
 func (formatter *TemplateFormatter) Format(captures []string) string {
 	if formatter.captureCount == 0 {
 		// no label substitution, keep as it is

--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -282,11 +282,19 @@ func (m *MetricMapper) GetMapping(statsdMetric string, statsdMetricType MetricTy
 		if finalState != nil && finalState.Result != nil {
 			v := finalState.Result.(*MetricMapping)
 			result := copyMetricMapping(v)
-			result.Name = result.nameFormatter.Format(captures)
+
+			// The formatters index into this slice directly, so the whole
+			// metric name goes first to be referenced as $0, like the regex
+			// match type allows.
+			templateCaptures := make([]string, 0, len(captures)+1)
+			templateCaptures = append(templateCaptures, statsdMetric)
+			templateCaptures = append(templateCaptures, captures...)
+
+			result.Name = result.nameFormatter.Format(templateCaptures)
 
 			labels := prometheus.Labels{}
 			for index, formatter := range result.labelFormatters {
-				labels[result.labelKeys[index]] = formatter.Format(captures)
+				labels[result.labelKeys[index]] = formatter.Format(templateCaptures)
 			}
 
 			r := MetricMapperCacheResult{

--- a/pkg/mapper/mapper_test.go
+++ b/pkg/mapper/mapper_test.go
@@ -1399,6 +1399,45 @@ mappings:
 				},
 			},
 		},
+		// Config that uses $0 to reference the whole metric name in glob mode,
+		// the same way the regex match type allows.
+		{
+			testName: "$0 in glob mappings",
+			config: `mappings:
+- match: test.dispatcher.*.*
+  name: "dispatch_$0"
+  labels:
+    original: "$0"
+    processor: "$1"
+    action: "$2"
+    combined: "$0-$1"
+- match: verbatim.*
+  name: "verbatim"
+  labels:
+    original: "$0"
+    out_of_range: "$2"`,
+			mappings: mappings{
+				{
+					statsdMetric: "test.dispatcher.FooProcessor.send",
+					name:         "dispatch_test.dispatcher.FooProcessor.send",
+					labels: map[string]string{
+						"original":  "test.dispatcher.FooProcessor.send",
+						"processor": "FooProcessor",
+						"action":    "send",
+						"combined":  "test.dispatcher.FooProcessor.send-FooProcessor",
+					},
+				},
+				{
+					statsdMetric: "verbatim.thing",
+					name:         "verbatim",
+					labels: map[string]string{
+						"original": "verbatim.thing",
+						// References beyond the number of captures stay empty.
+						"out_of_range": "",
+					},
+				},
+			},
+		},
 	}
 
 	mapper := MetricMapper{}


### PR DESCRIPTION
Closes #444

In the regex match type `$0` references the whole metric name. Glob mappings supported this too, back when they were translated into regular expressions, but the move to a finite state machine dropped it.

`NewTemplateFormatter` rejects any reference below `$1` and silently replaces it with an empty string:

```go
if err != nil || idx > captureCount || idx < 1 {
    valueFormatter = strings.ReplaceAll(valueFormatter, match[0], "")
```

So for `test.dispatcher.FooProcessor.send` with `name: "prefix_$0"`, the two match types disagree:

| match type | resulting name |
| --- | --- |
| regex | `prefix_test.dispatcher.FooProcessor.send` |
| glob | `prefix_` |

## Change

The metric name is passed to the formatters as the first element of the capture slice, and the reference now indexes into it directly. `$0` is the whole metric name and `$1` onwards keep pointing at exactly the same captures as before. After the change both match types produce `prefix_test.dispatcher.FooProcessor.send`.

The change is contained: `NewTemplateFormatter` only has two callers and both are on the glob path. The regex path uses `regexp.ExpandString`, which already handles `$0` natively and is untouched.

Out-of-range references keep their existing behaviour — `$2` on a single-capture match still renders as an empty string.

Worth noting for review: the mapping cache is keyed on the full metric name (`formatKey(statsdMetric, statsdMetricType)`), so results containing a per-metric `$0` cache correctly rather than being shared across metrics that hit the same mapping.

## Testing

Added a scenario to `TestMetricMapperYAML` covering `$0` on its own, `$0` combined with `$1`, and an out-of-range reference. Verified locally:

- `go build ./...`
- `go vet ./...`
- `gofmt -l` clean
- `go test ./...` — full suite passes, no changes needed to existing expectations

## Docs

The README documented this as a limitation and linked to #444, so that note is replaced with a short glob example.
