### PR TITLE
line: parse DogStatsD container ID field on lines without tags

### DIFF
--- a/pkg/line/line.go
+++ b/pkg/line/line.go
@@ -226,6 +226,20 @@ func (p *Parser) LineToEvents(line string, sampleErrors prometheus.CounterVec, s
 		return events
 	}
 
+	// A DogStatsD line may carry a v1.2 container ID field (|c:<id>) without any
+	// |# tags. The container ID field is always the final pipe-delimited field and
+	// its value may itself contain ':' (for example |c:sha256:...), so such a line
+	// must skip the legacy multi-metric ':' split below, which would otherwise
+	// shred the field and drop the sample as malformed_container_id. A valid legacy
+	// line always ends in a bare stat type (c, g, ms, ...), never "c:<id>", so this
+	// check does not affect legacy multi-metric parsing.
+	usingDogStatsDContainerID := false
+	if idx := strings.LastIndex(elements[1], "|"); idx >= 0 {
+		if last := elements[1][idx+1:]; strings.HasPrefix(last, "c:") && len(last) > len("c:") {
+			usingDogStatsDContainerID = true
+		}
+	}
+
 	var samples []string
 	lineParts := strings.SplitN(elements[1], "|", 3)
 	if len(lineParts) < 2 {
@@ -258,8 +272,8 @@ func (p *Parser) LineToEvents(line string, sampleErrors prometheus.CounterVec, s
 			logger.Debug("bad line: invalid extended aggregate type", "line", line)
 			return events
 		}
-	} else if usingDogStatsDTags {
-		// disable multi-metrics
+	} else if usingDogStatsDTags || usingDogStatsDContainerID {
+		// disable multi-metrics for DogStatsD lines (|# tags and/or |c: container ID)
 		samples = elements[1:]
 	} else {
 		samples = strings.Split(elements[1], ":")

--- a/pkg/line/line_test.go
+++ b/pkg/line/line_test.go
@@ -839,6 +839,46 @@ func TestLineToEvents(t *testing.T) {
 				},
 			},
 		},
+		"dogstatsd container ID without tags (counter)": {
+			in: "foo:100|c|c:container123",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo",
+					CValue:      100,
+					CLabels:     map[string]string{"container_id": "container123"},
+				},
+			},
+		},
+		"dogstatsd container ID without tags (gauge)": {
+			in: "foo:50|g|c:gauge_container",
+			out: event.Events{
+				&event.GaugeEvent{
+					GMetricName: "foo",
+					GValue:      50,
+					GLabels:     map[string]string{"container_id": "gauge_container"},
+				},
+			},
+		},
+		"dogstatsd container ID without tags (timer)": {
+			in: "foo:1000|ms|c:timer_container",
+			out: event.Events{
+				&event.ObserverEvent{
+					OMetricName: "foo",
+					OValue:      1,
+					OLabels:     map[string]string{"container_id": "timer_container"},
+				},
+			},
+		},
+		"dogstatsd container ID without tags (complex value)": {
+			in: "foo:100|c|c:sha256:abcd1234efgh5678",
+			out: event.Events{
+				&event.CounterEvent{
+					CMetricName: "foo",
+					CValue:      100,
+					CLabels:     map[string]string{"container_id": "sha256:abcd1234efgh5678"},
+				},
+			},
+		},
 		"dogstatsd container ID with tags": {
 			in: "foo:100|c|#tag1:bar,tag2:baz|c:container456",
 			out: event.Events{


### PR DESCRIPTION
## Problem

The DogStatsD v1.2 container ID field (`|c:<id>`) can appear on a line that has **no `|#` tags** (for example a DogStatsD client with origin/container detection enabled but no constant tags configured). A counter then looks like:

```
my_counter:1|c|c:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
```

`LineToEvents` only treats a line as DogStatsD (and skips the legacy multi-metric `:` split) when it contains `|#`. Without tags, the line falls through to `strings.Split(elements[1], ":")`, which splits on **every** colon and shreds the container ID field:

```
"1|c|c:0123...ef"  ->  ["1|c|c", "0123...ef"]
```

The first fragment `1|c|c` parses value=`1`, type=`c`, and a trailing bare `c` that fails the container-ID check (`malformed_container_id`); the second fragment has too few parts (`malformed_component`). The sample is dropped and the metric is never exported, even though the same line **with** tags parses correctly:

```
my_counter:1|c|#env:prod|c:0123...ef   ->  ok, container_id label set
```

## Fix

Detect the container ID field (always the final `|`-delimited field) and, like `|#` tags, skip the legacy `:` split for such lines. A valid legacy multi-metric line always ends in a bare stat type (`c`, `g`, `ms`, ...), never `c:<id>`, so legacy parsing is unaffected.

## Tests

Adds `LineToEvents` cases for counter/gauge/timer/complex-value container-ID lines without tags. `gofmt`, `go vet`, and `go test ./...` pass.

---
Note: Claude was used to help investigate and prepare this change.
