### PR TITLE
feat: add ClearRegistry endpoint to clear all metrics immediately

### DIFF
--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -37,6 +37,7 @@ type Registry interface {
 	GetHistogram(metricName string, labels prometheus.Labels, help string, mapping *mapper.MetricMapping, metricsCount *prometheus.GaugeVec) (prometheus.Observer, error)
 	GetSummary(metricName string, labels prometheus.Labels, help string, mapping *mapper.MetricMapping, metricsCount *prometheus.GaugeVec) (prometheus.Observer, error)
 	RemoveStaleMetrics()
+	ClearRegistry()
 }
 
 type Exporter struct {

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -395,6 +395,25 @@ func (r *Registry) RemoveStaleMetrics() {
 	}
 }
 
+func (r *Registry) ClearRegistry() {
+	for metricName, metric := range r.Metrics {
+		for hash, rm := range metric.Metrics {
+			metric.Vectors[rm.VecKey].Holder.Delete(rm.Labels)
+			metric.Vectors[rm.VecKey].RefCount--
+			delete(metric.Metrics, hash)
+		}
+		// Clear vectors that have no remaining metrics
+		for vecHash, vec := range metric.Vectors {
+			if vec.RefCount <= 0 {
+				delete(metric.Vectors, vecHash)
+			}
+		}
+		if len(metric.Vectors) == 0 {
+			delete(r.Metrics, metricName)
+		}
+	}
+}
+
 // Calculates a hash of both the label names and values.
 func (r *Registry) HashLabels(labels prometheus.Labels) (metrics.LabelHash, []string) {
 	r.Hasher.Reset()


### PR DESCRIPTION
Fixes #637

Adds a ClearRegistry method to the Registry interface that immediately removes
all registered metrics. This allows users to clear the metric registry without
quitting the exporter.

Use case: When working with large clusters of statsd_exporter where the number
of instances changes or order changes, metrics distribution keys change due to
hashing on statsrelay. Users need a way to immediately forget accumulated
metrics and start collecting in a new distribution.

This is different from /-/reload (metrics persist) and /-/quit (disruptive).